### PR TITLE
Fix devtools::check bugs and documentation typos

### DIFF
--- a/R/example_data.R
+++ b/R/example_data.R
@@ -6,6 +6,7 @@
 #' @param scenario Character specifying the simulation scenario ("default", "easy", "poorSeparation", "cytPos").
 #' @param dirCache Directory to save the GatingSet. If NULL, uses a temporary directory.
 #' @param clear Logical indicating whether to force cache clearing.
+#' @param nCell Integer. Number of cells per condition to simulate. Default: 10000.
 #' @param nInd Integer. Number of biological samples to simulate.
 #' @return A list containing the path to the saved GatingSet, batchList, chnl, and marker names.
 #' @export

--- a/R/fcs_write.R
+++ b/R/fcs_write.R
@@ -21,7 +21,7 @@
 #' @details
 #' This function processes flow cytometry data to identify and export cytokine-positive
 #' cells to FCS files. It requires that gates have been pre-computed using
-#' \code{\link{stimgate_gate}} or that a complete gate table is provided.
+#' \code{\link{gateStim}} or that a complete gate table is provided.
 #'
 #' The function will create the output directory and write FCS files for samples
 #' that contain cytokine-positive cells. If no positive cells are found in a sample,
@@ -38,7 +38,7 @@
 #'
 #' # First, run gating to create gates
 #' pathProject <- tempfile("stimgate_project")
-#' # stimgate_gate(
+#' # gateStim(
 #' #   .data = gs,
 #' #   pathProject = pathProject,
 #' #   popGate = "root",
@@ -274,7 +274,7 @@ writeStimFCS <- function(
 #' @keywords internal
 .fcsWriteGetGateTblAddUnsGetUnsCalc <- function(gateUnsMethod) {
   switch(
-    gate_uns_method,
+    gateUnsMethod,
     "min" = min,
     "max" = max,
     "mean" = mean,

--- a/R/gate.R
+++ b/R/gate.R
@@ -289,9 +289,9 @@
 #' \code{\link{writeStimFCS}} for exporting cytokine-positive cells,
 #' \code{\link[flowWorkspace]{GatingSet}} for GatingSet documentation
 #'
-#' @examples{
+#' @examples
 #' exampleData <- getExampleData()
-#' gs <- flowWorkspace::load_gs(exampleData$path_gs)
+#' gs <- flowWorkspace::load_gs(exampleData$pathGs)
 #' pathProject <- file.path(tempdir(), "demonstration")
 #'
 #' # Run gating
@@ -311,10 +311,6 @@
 #'   marker = exampleData$marker,
 #'   grid = TRUE
 #' )
-#'
-#' # Advanced usage with parameter customization
-#'
-#' }
 #' @importFrom flowCore exprs<- parameters<-
 #' @importFrom stats approx as.formula binomial density glm kmeans median optim predict quantile rnorm sd dnorm fft
 #' @importFrom utils read.csv write.csv

--- a/R/gates.R
+++ b/R/gates.R
@@ -8,9 +8,9 @@
 #' @param chnl character. Optional channel name(s) to filter gates by. Default is NULL (all channels).
 #'
 #' @return Gate table with gates for each sample for each marker.
-#' @examples{
+#' @examples
 #' # Get example dataset
-#' exampleData <- get_example_data()
+#' exampleData <- getExampleData()
 #' gs <- flowWorkspace::load_gs(exampleData$pathGs)
 #'
 #' # Run the stimgate pipeline
@@ -24,7 +24,6 @@
 #'
 #' # Get statistics for the identified gates
 #' gates <- getStimGates(pathProject)
-#' }
 #' @export
 getStimGates <- function(
   pathProject,
@@ -36,14 +35,14 @@ getStimGates <- function(
 
   purrr::map_df(pop, function(popCurr) {
     chnlVec <- if (!is.null(marker)) {
-      markerLab <- stimgateMetReadMarkerLab(pathProject)
+      markerLab <- stimgateMetaReadMarkerLab(pathProject)
       markerLab[marker] |> stats::setNames(NULL)
     } else {
       chnl %|c|% .gateGetChnl(pathProject, popCurr)
     }
 
     purrr::map_df(chnlVec, function(chnlCurr) {
-      markerCurr <- stimgateMetReadChnlLab(pathProject)[chnlCurr] |>
+      markerCurr <- stimgateMetaReadChnlLab(pathProject)[chnlCurr] |>
         stats::setNames(NULL)
 
       .gatesGetPathAll(

--- a/R/plot_gate.R
+++ b/R/plot_gate.R
@@ -4,9 +4,9 @@
 #' with their gates.
 #'
 #' @param ind numeric vector. Specifies indices in `.data` to plot.
-#' @param .data GatingSet. Same GatingSet passed to `stimgate_gate`.
+#' @param .data GatingSet. Same GatingSet passed to `gateStim`.
 #' @param pathProject character.
-#' Path to the project directory used for `stimgate_gate`.
+#' Path to the project directory used for `gateStim`.
 #' @param marker character vector of length one or two. Specifies markers
 #' to be plotted. If only one is passed, then only univariate plots are created.
 #' @param chnl character vector of length one or two. Specifies channels
@@ -51,12 +51,12 @@
 #'
 #' @examples
 #' # Create example data and run gating
-#' exampleData <- get_example_data()
-#' gs <- flowWorkspace::load_gs(exampleData$path_gs)
-#' pathProject <- file.path(dirname(exampleData$path_gs), "stimgate")
+#' exampleData <- getExampleData()
+#' gs <- flowWorkspace::load_gs(exampleData$pathGs)
+#' pathProject <- file.path(dirname(exampleData$pathGs), "stimgate")
 #'
 #' # Run gating
-#' stimgate::stimgate_gate(
+#' gateStim(
 #'   .data = gs,
 #'   pathProject = pathProject,
 #'   popGate = "root",
@@ -65,7 +65,7 @@
 #' )
 #'
 #' # Create plots
-#' plots <- stimgate_plot(
+#' plots <- plotStim(
 #'   ind = exampleData$batchList[[1]], # indices in `gs` to plot
 #'   .data = gs, # GatingSet
 #'   pathProject = pathProject,
@@ -390,8 +390,8 @@ plotStim <- function(
   if (!showGate) {
     return(p)
   }
-  marker <- marker %||% stimgateMetaReadchnlLab(pathProject)[chnl]
-  chnl <- chnl %||% stimgateMetaReadmarkerLab(pathProject)[marker]
+  marker <- marker %||% stimgateMetaReadChnlLab(pathProject)[chnl]
+  chnl <- chnl %||% stimgateMetaReadMarkerLab(pathProject)[marker]
   pop <- pop %||% .gateGetPop(pathProject)
   if (length(pop) > 1L) {
     stop("Cannot plot gates for multiple populations")

--- a/R/stats.R
+++ b/R/stats.R
@@ -121,7 +121,7 @@
 #' @param pathProject character. Path to the project directory.
 #' @return A data frame with gating statistics.
 #' @export
-getStimGates <- function(pathProject) {
+getStimStats <- function(pathProject) {
   pathStatsPartial <- file.path(pathProject, "gateStats")
   if (file.exists(paste0(pathStatsPartial, ".rds"))) {
     readRDS(paste0(pathStatsPartial, ".rds"))

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,29 +6,33 @@ reference:
 - title: Gating Functions
   desc: Main functions for identifying cytokine-positive cells
   contents:
-  - stimgate_gate
-  - stimgate_gate_get
+  - gateStim
+  - getStimGates
+  - getStimGatesDetailed
 
 - title: Statistics and Results
   desc: Functions for extracting gating results and statistics
   contents:
-  - get_stats
+  - getStimStats
 
 - title: Visualization
   desc: Functions for plotting gates and results
   contents:
-  - stimgate_plot
+  - plotStim
 
 - title: Data Export
   desc: Functions for exporting gated data
   contents:
-  - stimgate_fcs_write
+  - writeStimFCS
 
 - title: Utilities
   desc: Helper and utility functions
   contents:
-  - chnl_lab
-  - get_example_data
+  - chnlLab
+  - getExampleData
+  - getStimExpr
+  - stimgate_debug_copy
+  - stimgate_debug_print
 
 navbar:
   structure:

--- a/tests/testthat/test-coverage-gaps.R
+++ b/tests/testthat/test-coverage-gaps.R
@@ -69,7 +69,7 @@ test_that("stimgateGateRunsWithGateCombnMean", {
 
   # Test with mean gate combination
   expect_no_error({
-    result <- stimgate::stimgate_gate(
+    result <- stimgate::gateStim(
       .data = gs,
       pathProject = pathProject,
       popGate = "root",
@@ -99,7 +99,7 @@ test_that("stimgateGateRunsWithGateCombnTrim20", {
 
   # Test with trim20 gate combination
   expect_no_error({
-    result <- stimgate::stimgate_gate(
+    result <- stimgate::gateStim(
       .data = gs,
       pathProject = pathProject,
       popGate = "root",
@@ -129,7 +129,7 @@ test_that("stimgateGateRunsWithGateCombnMedian", {
 
   # Test with median gate combination
   expect_no_error({
-    result <- stimgate::stimgate_gate(
+    result <- stimgate::gateStim(
       .data = gs,
       pathProject = pathProject,
       popGate = "root",
@@ -159,7 +159,7 @@ test_that("stimgateGateRunsWithGateCombnMax", {
 
   # Test with max gate combination
   expect_no_error({
-    result <- stimgate::stimgate_gate(
+    result <- stimgate::gateStim(
       .data = gs,
       pathProject = pathProject,
       popGate = "root",

--- a/tests/testthat/test-cyt_pos.R
+++ b/tests/testthat/test-cyt_pos.R
@@ -3,13 +3,13 @@ library(testthat)
 test_that("cytPos gates actually happen", {
   testData <- getTestData(
     scenario = "cytPos",
-    dir_cache = testthat::test_path("cache", "test_data", "default"),
+    dirCache = testthat::test_path("cache", "test_data", "default"),
     clear = TRUE,
-    n_ind = 1
+    nInd = 1
   )
-  gs <- flowWorkspace::load_gs(testData$path_gs)
-  pathProject <- file.path(dirname(testData$path_gs), "stimgate")
-  invisible(stimgate_gate(
+  gs <- flowWorkspace::load_gs(testData$pathGs)
+  pathProject <- file.path(dirname(testData$pathGs), "stimgate")
+  invisible(gateStim(
     .data = gs,
     pathProject = pathProject,
     popGate = "root",

--- a/tests/testthat/test-ex.R
+++ b/tests/testthat/test-ex.R
@@ -1,4 +1,4 @@
-test_that("stimgateDataGetEx reads saved channel data and filters correctly", {
+test_that("getStimExpr reads saved channel data and filters correctly", {
   tmp <- tempfile("stimgate_ex_")
   dir.create(
     file.path(tmp, "sampleData", "pop_POP1", "ind_1"),
@@ -25,24 +25,24 @@ test_that("stimgateDataGetEx reads saved channel data and filters correctly", {
     c(9, 10),
     file = file.path(tmp, "sampleData", "pop_POP1", "ind_2", "chnl_BC2.rds")
   )
-  res <- stimgateDataGetEx(tmp)
+  res <- getStimExpr(tmp)
   expect_equal(nrow(res), 5)
   expect_true(all(c("pop", "ind", "BC1", "BC2") %in% names(res)))
   expect_equal(unique(res$pop), "POP1")
   expect_equal(sum(res$ind == "1"), 3)
   expect_equal(sum(res$ind == "2"), 2)
 
-  resBc1 <- stimgateDataGetEx(tmp, chnl = "BC1")
+  resBc1 <- getStimExpr(tmp, chnl = "BC1")
   expect_true("BC1" %in% names(resBc1))
   expect_false("BC2" %in% names(resBc1))
 
-  resInd1 <- stimgateDataGetEx(tmp, ind = "1")
+  resInd1 <- getStimExpr(tmp, ind = "1")
   expect_equal(nrow(resInd1), 3)
 
-  expect_error(stimgateDataGetEx(""))
+  expect_error(getStimExpr(""))
 })
 
-test_that("stimgateDataGetEx applies bias only to unstim sample", {
+test_that("getStimExpr applies bias only to unstim sample", {
   tmp <- tempfile("stimgate_ex_bias_")
   dir.create(
     file.path(tmp, "sampleData", "pop_POP1", "ind_1"),
@@ -81,17 +81,17 @@ test_that("stimgateDataGetEx applies bias only to unstim sample", {
   saveRDS(batchList, file.path(tmp, "metaData", "batchList.rds"))
 
   # unstim is ind 2 -> expect bias added
-  resUns <- stimgateDataGetEx(tmp, ind = "2", bias = TRUE)
+  resUns <- getStimExpr(tmp, ind = "2", bias = TRUE)
   expect_equal(resUns$BC1, c(7 + 10, 8 + 10))
   expect_equal(resUns$BC2, c(9 - 2, 10 - 2))
 
   # stim is ind 1 -> bias should not be applied
-  resStim <- stimgateDataGetEx(tmp, ind = "1", bias = TRUE)
+  resStim <- getStimExpr(tmp, ind = "1", bias = TRUE)
   expect_equal(resStim$BC1, c(1, 2, 3))
   expect_equal(resStim$BC2, c(4, 5, 6))
 })
 
-test_that("stimgateDataGetEx excludes minimum observed values when excMin = TRUE", {
+test_that("getStimExpr excludes minimum observed values when excMin = TRUE", {
   tmp <- tempfile("stimgate_ex_excmin_")
   dir.create(
     file.path(tmp, "sampleData", "pop_POP1", "ind_1"),
@@ -108,16 +108,16 @@ test_that("stimgateDataGetEx excludes minimum observed values when excMin = TRUE
     file = file.path(tmp, "sampleData", "pop_POP1", "ind_1", "chnl_BC2.rds")
   )
 
-  resNoexc <- stimgateDataGetEx(tmp, ind = "1", excMin = FALSE)
+  resNoexc <- getStimExpr(tmp, ind = "1", excMin = FALSE)
   expect_equal(nrow(resNoexc), 3)
 
-  resExc <- stimgateDataGetEx(tmp, ind = "1", excMin = TRUE)
+  resExc <- getStimExpr(tmp, ind = "1", excMin = TRUE)
   expect_equal(nrow(resExc), 1)
   expect_equal(resExc$BC1, 3)
   expect_equal(resExc$BC2, 6)
 })
 
-test_that("stimgateDataGetEx uses marker parameter to rename channels", {
+test_that("getStimExpr uses marker parameter to rename channels", {
   tmp <- tempfile("stimgate_ex_marker_")
   dir.create(
     file.path(tmp, "sampleData", "pop_POP1", "ind_1"),
@@ -138,13 +138,13 @@ test_that("stimgateDataGetEx uses marker parameter to rename channels", {
   dir.create(file.path(tmp, "metaData"), showWarnings = FALSE)
   saveRDS(chnlLab, file.path(tmp, "metaData", "chnlLab.rds"))
 
-  res <- stimgateDataGetEx(tmp, marker = "IFNg")
+  res <- getStimExpr(tmp, marker = "IFNg")
   expect_true("IFNg" %in% names(res))
   expect_false("BC1" %in% names(res))
   expect_equal(res$IFNg, c(1, 2, 3))
 })
 
-test_that("stimgateDataGetEx errors when both marker and chnl specified", {
+test_that("getStimExpr errors when both marker and chnl specified", {
   tmp <- tempfile("stimgate_ex_marker_chnl_conflict_")
   dir.create(
     file.path(tmp, "sampleData", "pop_POP1", "ind_1"),
@@ -157,12 +157,12 @@ test_that("stimgateDataGetEx errors when both marker and chnl specified", {
   )
 
   expect_error(
-    stimgateDataGetEx(tmp, marker = "IFNg", chnl = "BC1"),
+    getStimExpr(tmp, marker = "IFNg", chnl = "BC1"),
     "Must not specify both marker and chnl"
   )
 })
 
-test_that("stimgateDataGetEx applies transFn to specified channels", {
+test_that("getStimExpr applies transFn to specified channels", {
   tmp <- tempfile("stimgate_ex_trans_")
   dir.create(
     file.path(tmp, "sampleData", "pop_POP1", "ind_1"),
@@ -180,12 +180,12 @@ test_that("stimgateDataGetEx applies transFn to specified channels", {
 
   # Test transforming all channels
   transFnDouble <- function(x) x * 2
-  resAll <- stimgateDataGetEx(tmp, transFn = transFnDouble)
+  resAll <- getStimExpr(tmp, transFn = transFnDouble)
   expect_equal(resAll$BC1, c(2, 4, 6))
   expect_equal(resAll$BC2, c(8, 10, 12))
 
   # Test transforming only BC1
-  resBc1 <- stimgateDataGetEx(
+  resBc1 <- getStimExpr(
     tmp,
     transFn = transFnDouble,
     transChnl = "BC1"
@@ -194,7 +194,7 @@ test_that("stimgateDataGetEx applies transFn to specified channels", {
   expect_equal(resBc1$BC2, c(4, 5, 6))
 })
 
-test_that("stimgateDataGetEx applies transFn to markers when using marker parameter", {
+test_that("getStimExpr applies transFn to markers when using marker parameter", {
   tmp <- tempfile("stimgate_ex_trans_marker_")
   dir.create(
     file.path(tmp, "sampleData", "pop_POP1", "ind_1"),
@@ -216,7 +216,7 @@ test_that("stimgateDataGetEx applies transFn to markers when using marker parame
   saveRDS(chnlLab, file.path(tmp, "metaData", "chnlLab.rds"))
 
   transFnDouble <- function(x) x * 2
-  res <- stimgateDataGetEx(
+  res <- getStimExpr(
     tmp,
     marker = c("IFNg", "IL2"),
     transFn = transFnDouble,
@@ -226,7 +226,7 @@ test_that("stimgateDataGetEx applies transFn to markers when using marker parame
   expect_equal(res$IL2, c(4, 5, 6))
 })
 
-test_that("stimgateDataGetEx errors when both chnlGate and markerGate specified", {
+test_that("getStimExpr errors when both chnlGate and markerGate specified", {
   tmp <- tempfile("stimgate_ex_gate_conflict_")
   dir.create(
     file.path(tmp, "sampleData", "pop_POP1", "ind_1"),
@@ -244,19 +244,19 @@ test_that("stimgateDataGetEx errors when both chnlGate and markerGate specified"
   saveRDS(chnlLab, file.path(tmp, "metaData", "chnlLab.rds"))
 
   expect_error(
-    stimgateDataGetEx(tmp, chnlGate = "BC1", markerGate = "IFNg"),
+    getStimExpr(tmp, chnlGate = "BC1", markerGate = "IFNg"),
     "Must not specify both chnlGate and markerGate"
   )
 })
 
-test_that("stimgateDataGetEx extracts cytokine-positive cells with gating", {
+test_that("getStimExpr extracts cytokine-positive cells with gating", {
   # Use example data and run gating
-  example_data <- get_example_data()
-  gs <- flowWorkspace::load_gs(example_data$path_gs)
+  example_data <- getExampleData()
+  gs <- flowWorkspace::load_gs(example_data$pathGs)
   pathProject <- file.path(tempdir(), "stimgate_ex_cytPos_test")
 
   # Run gating
-  invisible(stimgate_gate(
+  invisible(gateStim(
     .data = gs,
     pathProject = pathProject,
     popGate = "root",
@@ -265,7 +265,7 @@ test_that("stimgateDataGetEx extracts cytokine-positive cells with gating", {
   ))
 
   # Get gates to verify they exist
-  gateTbl <- stimgateGateGet(pathProject)
+  gateTbl <- getStimGates(pathProject)
   expect_true(nrow(gateTbl) > 0)
   expect_true(all(c("chnl", "ind", "gateCyt") %in% names(gateTbl)))
 
@@ -274,7 +274,7 @@ test_that("stimgateDataGetEx extracts cytokine-positive cells with gating", {
   expect_true(length(chnlGated) > 0)
 
   # Test extracting all cells without gating (baseline)
-  exAll <- stimgateDataGetEx(
+  exAll <- getStimExpr(
     pathProject,
     pop = "root",
     chnl = chnlGated[[1]]
@@ -286,7 +286,7 @@ test_that("stimgateDataGetEx extracts cytokine-positive cells with gating", {
   # We're testing that the functionality works, not that we get positive cells
   resCytPos <- tryCatch(
     {
-      stimgateDataGetEx(
+      getStimExpr(
         pathProject,
         pop = "root",
         chnl = chnlGated[[1]],
@@ -334,7 +334,7 @@ test_that("stimgateDataGetEx extracts cytokine-positive cells with gating", {
 
   resMarkerGate <- tryCatch(
     {
-      stimgateDataGetEx(
+      getStimExpr(
         pathProject,
         pop = "root",
         marker = markerName,
@@ -360,7 +360,7 @@ test_that("stimgateDataGetEx extracts cytokine-positive cells with gating", {
   if (length(chnlGated) >= 2) {
     resMult <- tryCatch(
       {
-        stimgateDataGetEx(
+        getStimExpr(
           pathProject,
           pop = "root",
           chnl = chnlGated,

--- a/tests/testthat/test-fcs_write.R
+++ b/tests/testthat/test-fcs_write.R
@@ -1,7 +1,7 @@
-exampleData <- get_example_data()
-gs <- flowWorkspace::load_gs(exampleData$path_gs)
-pathProject <- file.path(dirname(exampleData$path_gs), "stimgate")
-invisible(stimgate_gate(
+exampleData <- getExampleData()
+gs <- flowWorkspace::load_gs(exampleData$pathGs)
+pathProject <- file.path(dirname(exampleData$pathGs), "stimgate")
+invisible(gateStim(
   .data = gs,
   pathProject = pathProject,
   popGate = "root",
@@ -9,7 +9,7 @@ invisible(stimgate_gate(
   chnl = exampleData$chnl
 ))
 
-# Comprehensive test suite for stimgate_fcs_write function
+# Comprehensive test suite for writeStimFCS function
 # Tests cover:
 # 1. Basic functionality and parameter validation
 # 2. Directory management (creation, cleanup, relative paths)
@@ -20,12 +20,12 @@ invisible(stimgate_gate(
 # 7. Error handling and message output
 # 8. Channel filtering and combination exclusions
 
-test_that("stimgate_fcs_write function exists and has correct signature", {
+test_that("writeStimFCS function exists and has correct signature", {
   # Test that the function exists and has the expected parameters
-  expect_true(exists("stimgate_fcs_write", where = asNamespace("stimgate")))
+  expect_true(exists("writeStimFCS", where = asNamespace("stimgate")))
 
   # Test function signature by checking for argument names
-  args <- names(formals(stimgate_fcs_write))
+  args <- names(formals(writeStimFCS))
   expectedArgs <- c(
     "pathProject",
     ".data",
@@ -46,11 +46,11 @@ test_that("stimgate_fcs_write function exists and has correct signature", {
 })
 
 
-test_that("stimgate_fcs_write runs with basic parameters", {
+test_that("writeStimFCS runs with basic parameters", {
   pathDirSave <- file.path(tempdir(), "fcs_output_test")
 
   # Function should create the directory before failing on missing gates
-  result <- stimgate_fcs_write(
+  result <- writeStimFCS(
     pathProject = pathProject,
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -74,12 +74,12 @@ test_that("stimgate_fcs_write runs with basic parameters", {
   unlink(pathDirSave, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write handles directory creation and cleanup", {
+test_that("writeStimFCS handles directory creation and cleanup", {
   # Test with non-existent directory
   pathDirSave <- file.path(tempdir(), "new_fcs_dir", "subdir")
   expect_false(dir.exists(pathDirSave))
 
-  stimgate_fcs_write(
+  writeStimFCS(
     pathProject = pathProject,
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -96,7 +96,7 @@ test_that("stimgate_fcs_write handles directory creation and cleanup", {
   expect_true(file.exists(dummyFile))
 
   # Run again - should clean directory
-  stimgate_fcs_write(
+  writeStimFCS(
     pathProject = pathProject,
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -108,13 +108,13 @@ test_that("stimgate_fcs_write handles directory creation and cleanup", {
   unlink(pathDirSave, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write works with different gateUnsMethod options", {
+test_that("writeStimFCS works with different gateUnsMethod options", {
   gateMethods <- c("min", "max", "mean", "tmean", "med")
 
   for (method in gateMethods) {
     pathDirSave <- file.path(tempdir(), paste0("fcs_output_", method))
 
-    result <- stimgate_fcs_write(
+    result <- writeStimFCS(
       pathProject = pathProject,
       .data = gs,
       indBatchList = exampleData$batchList,
@@ -131,10 +131,10 @@ test_that("stimgate_fcs_write works with different gateUnsMethod options", {
   }
 })
 
-test_that("stimgate_fcs_write works with mult parameter", {
+test_that("writeStimFCS works with mult parameter", {
   # Test with mult = FALSE (default)
   pathDirSaveSingle <- file.path(tempdir(), "fcs_output_single")
-  resultSingle <- stimgate_fcs_write(
+  resultSingle <- writeStimFCS(
     pathProject = pathProject,
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -145,7 +145,7 @@ test_that("stimgate_fcs_write works with mult parameter", {
 
   # Test with mult = TRUE
   pathDirSaveMult <- file.path(tempdir(), "fcs_output_mult")
-  resultMult <- stimgate_fcs_write(
+  resultMult <- writeStimFCS(
     pathProject = pathProject,
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -162,10 +162,10 @@ test_that("stimgate_fcs_write works with mult parameter", {
   unlink(pathDirSaveMult, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write works with different gate types", {
+test_that("writeStimFCS works with different gate types", {
   pathDirSave <- file.path(tempdir(), "fcs_output_gate_types")
 
-  result <- stimgate_fcs_write(
+  result <- writeStimFCS(
     pathProject = pathProject,
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -180,10 +180,10 @@ test_that("stimgate_fcs_write works with different gate types", {
   unlink(pathDirSave, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write validates output file contents", {
+test_that("writeStimFCS validates output file contents", {
   pathDirSave <- file.path(tempdir(), "fcs_output_validation")
 
-  stimgate_fcs_write(
+  writeStimFCS(
     pathProject = pathProject,
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -217,7 +217,7 @@ test_that("stimgate_fcs_write validates output file contents", {
   unlink(pathDirSave, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write works with pre-provided gate table", {
+test_that("writeStimFCS works with pre-provided gate table", {
   # Create a simple gate table
   gateTbl <- data.frame(
     chnl = rep(exampleData$chnl[[1]], length(unlist(exampleData$batchList))),
@@ -238,7 +238,7 @@ test_that("stimgate_fcs_write works with pre-provided gate table", {
 
   pathDirSave <- file.path(tempdir(), "fcs_output_custom_gate")
 
-  result <- stimgate_fcs_write(
+  result <- writeStimFCS(
     pathProject = tempdir(), # Not used when gateTbl provided
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -252,11 +252,11 @@ test_that("stimgate_fcs_write works with pre-provided gate table", {
   unlink(pathDirSave, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write handles invalid gateUnsMethod", {
+test_that("writeStimFCS handles invalid gateUnsMethod", {
   pathDirSave <- file.path(tempdir(), "fcs_output_invalid")
 
   expect_error(
-    stimgate_fcs_write(
+    writeStimFCS(
       pathProject = pathProject,
       .data = gs,
       indBatchList = exampleData$batchList,
@@ -269,11 +269,11 @@ test_that("stimgate_fcs_write handles invalid gateUnsMethod", {
   unlink(pathDirSave, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write works with channel filtering", {
+test_that("writeStimFCS works with channel filtering", {
   # Test with specific channel subset
   pathDirSave <- file.path(tempdir(), "fcs_output_filtered")
 
-  result <- stimgate_fcs_write(
+  result <- writeStimFCS(
     pathProject = pathProject,
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -287,7 +287,7 @@ test_that("stimgate_fcs_write works with channel filtering", {
   # Test with NULL chnl (should use all available)
   pathDirSaveAll <- file.path(tempdir(), "fcs_output_all")
 
-  resultAll <- stimgate_fcs_write(
+  resultAll <- writeStimFCS(
     pathProject = pathProject,
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -300,14 +300,14 @@ test_that("stimgate_fcs_write works with channel filtering", {
   unlink(pathDirSave, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write handles transformation parameters", {
+test_that("writeStimFCS handles transformation parameters", {
   # Test with transformation function
   pathDirSave <- file.path(tempdir(), "fcs_output_transform")
 
   # Simple log transformation
   logTransform <- function(x) log10(x + 1)
 
-  result <- stimgate_fcs_write(
+  result <- writeStimFCS(
     pathProject = pathProject,
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -326,10 +326,10 @@ test_that("stimgate_fcs_write handles transformation parameters", {
   unlink(pathDirSave, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write preserves file metadata", {
+test_that("writeStimFCS preserves file metadata", {
   pathDirSave <- file.path(tempdir(), "fcs_output_metadata")
 
-  stimgate_fcs_write(
+  writeStimFCS(
     pathProject = pathProject,
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -359,14 +359,14 @@ test_that("stimgate_fcs_write preserves file metadata", {
   unlink(pathDirSave, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write handles combination exclusions", {
+test_that("writeStimFCS handles combination exclusions", {
   pathDirSave <- file.path(tempdir(), "fcs_output_exclusions")
 
   # Test with combination exclusions (if we have multiple markers)
   if (length(exampleData$chnl) > 1) {
     combnExc <- list(exampleData$chnl[[1]])
 
-    result <- stimgate_fcs_write(
+    result <- writeStimFCS(
       pathProject = pathProject,
       .data = gs,
       indBatchList = exampleData$batchList,
@@ -379,7 +379,7 @@ test_that("stimgate_fcs_write handles combination exclusions", {
     expect_true(dir.exists(pathDirSave))
   } else {
     # Test with NULL exclusions
-    result <- stimgate_fcs_write(
+    result <- writeStimFCS(
       pathProject = pathProject,
       .data = gs,
       indBatchList = exampleData$batchList,
@@ -394,10 +394,10 @@ test_that("stimgate_fcs_write handles combination exclusions", {
   unlink(pathDirSave, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write creates consistent file names", {
+test_that("writeStimFCS creates consistent file names", {
   pathDirSave <- file.path(tempdir(), "fcs_output_naming")
 
-  stimgate_fcs_write(
+  writeStimFCS(
     pathProject = pathProject,
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -423,12 +423,12 @@ test_that("stimgate_fcs_write creates consistent file names", {
   unlink(pathDirSave, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write message output", {
+test_that("writeStimFCS message output", {
   pathDirSave <- file.path(tempdir(), "fcs_output_messages")
 
   # Capture messages
   expect_message(
-    stimgate_fcs_write(
+    writeStimFCS(
       pathProject = pathProject,
       .data = gs,
       indBatchList = exampleData$batchList,
@@ -440,7 +440,7 @@ test_that("stimgate_fcs_write message output", {
   unlink(pathDirSave, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write handles edge case: empty data", {
+test_that("writeStimFCS handles edge case: empty data", {
   # Create gate table with very high thresholds (should result in no positive cells)
   gateTbl <- data.frame(
     chnl = rep(exampleData$chnl[[1]], length(unlist(exampleData$batchList))),
@@ -463,7 +463,7 @@ test_that("stimgate_fcs_write handles edge case: empty data", {
 
   # Should handle case where no cells meet criteria
   expect_message(
-    result <- stimgate_fcs_write(
+    result <- writeStimFCS(
       pathProject = tempdir(),
       .data = gs,
       indBatchList = exampleData$batchList,
@@ -479,10 +479,10 @@ test_that("stimgate_fcs_write handles edge case: empty data", {
   unlink(pathDirSave, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write validates parameter types", {
+test_that("writeStimFCS validates parameter types", {
   # Test with invalid .data type (should fail gracefully)
   expect_error(
-    stimgate_fcs_write(
+    writeStimFCS(
       pathProject = tempdir(),
       .data = "not_a_gatingset",
       indBatchList = exampleData$batchList,
@@ -493,7 +493,7 @@ test_that("stimgate_fcs_write validates parameter types", {
 
   # Test with invalid indBatchList type
   expect_error(
-    stimgate_fcs_write(
+    writeStimFCS(
       pathProject = tempdir(),
       .data = gs,
       indBatchList = "not_a_list",
@@ -504,14 +504,14 @@ test_that("stimgate_fcs_write validates parameter types", {
 })
 
 
-test_that("stimgate_fcs_write integrates with stimgate workflow", {
+test_that("writeStimFCS integrates with stimgate workflow", {
   # Test full integration: gate -> fcs_write -> verify output
-  exampleData <- get_example_data()
-  gs <- flowWorkspace::load_gs(exampleData$path_gs)
-  pathProject <- file.path(dirname(exampleData$path_gs), "stimgate")
+  exampleData <- getExampleData()
+  gs <- flowWorkspace::load_gs(exampleData$pathGs)
+  pathProject <- file.path(dirname(exampleData$pathGs), "stimgate")
 
   # Step 1: Run gating
-  invisible(stimgate_gate(
+  invisible(gateStim(
     .data = gs,
     pathProject = pathProject,
     popGate = "root",
@@ -525,7 +525,7 @@ test_that("stimgate_fcs_write integrates with stimgate workflow", {
   # Step 2: Run FCS writing using gates from step 1
   pathDirSave <- file.path(tempdir(), "fcs_output_integration")
 
-  result <- stimgate_fcs_write(
+  result <- writeStimFCS(
     pathProject = pathProject,
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -553,15 +553,15 @@ test_that("stimgate_fcs_write integrates with stimgate workflow", {
   unlink(pathDirSave, recursive = TRUE)
 })
 
-test_that("stimgate_fcs_write respects working directory", {
+test_that("writeStimFCS respects working directory", {
   # Change working directory temporarily
   originalWd <- getwd()
   tempWd <- tempdir()
 
-  exampleData <- get_example_data()
-  gs <- flowWorkspace::load_gs(exampleData$path_gs)
-  pathProject2 <- file.path(dirname(exampleData$path_gs), "stimgate")
-  invisible(stimgate_gate(
+  exampleData <- getExampleData()
+  gs <- flowWorkspace::load_gs(exampleData$pathGs)
+  pathProject2 <- file.path(dirname(exampleData$pathGs), "stimgate")
+  invisible(gateStim(
     .data = gs,
     pathProject = pathProject2,
     popGate = "root",
@@ -576,7 +576,7 @@ test_that("stimgate_fcs_write respects working directory", {
       # Use relative path for output
       pathDirSave <- "fcs_output_wd_test"
 
-      result <- stimgate_fcs_write(
+      result <- writeStimFCS(
         pathProject = pathProject2,
         .data = gs,
         indBatchList = exampleData$batchList,
@@ -596,11 +596,11 @@ test_that("stimgate_fcs_write respects working directory", {
 })
 
 
-test_that("stimgate_fcs_write handles transformation edge cases", {
-  exampleData <- get_example_data()
-  gs <- flowWorkspace::load_gs(exampleData$path_gs)
-  pathProject2 <- file.path(dirname(exampleData$path_gs), "stimgate")
-  invisible(stimgate_gate(
+test_that("writeStimFCS handles transformation edge cases", {
+  exampleData <- getExampleData()
+  gs <- flowWorkspace::load_gs(exampleData$pathGs)
+  pathProject2 <- file.path(dirname(exampleData$pathGs), "stimgate")
+  invisible(gateStim(
     .data = gs,
     pathProject = pathProject2,
     popGate = "root",
@@ -614,7 +614,7 @@ test_that("stimgate_fcs_write handles transformation edge cases", {
   # Identity transformation (should not change values but test the pathway)
   identityTransform <- function(x) x
 
-  result <- stimgate::stimgate_fcs_write(
+  result <- stimgate::writeStimFCS(
     pathProject = pathProject2,
     .data = gs,
     indBatchList = exampleData$batchList,
@@ -630,7 +630,7 @@ test_that("stimgate_fcs_write handles transformation edge cases", {
   # Test with NULL transformation function
   pathDirSaveNull <- file.path(tempdir(), "fcs_output_transform_null")
 
-  resultNull <- stimgate::stimgate_fcs_write(
+  resultNull <- stimgate::writeStimFCS(
     pathProject = pathProject2,
     .data = gs,
     indBatchList = exampleData$batchList,

--- a/tests/testthat/test-gate-get.R
+++ b/tests/testthat/test-gate-get.R
@@ -1,6 +1,6 @@
 library(testthat)
 
-test_that("stimgate_gate_get returns gate table after stimgate_gate", {
+test_that("getStimGates returns gate table after gateStim", {
   # Skip if we can't load the required package
   skip_if_not_installed("stimgate")
 
@@ -8,15 +8,15 @@ test_that("stimgate_gate_get returns gate table after stimgate_gate", {
   library(stimgate)
 
   # Get example data
-  exampleData <- get_example_data()
-  gs <- flowWorkspace::load_gs(exampleData$path_gs)
+  exampleData <- getExampleData()
+  gs <- flowWorkspace::load_gs(exampleData$pathGs)
   pathProject <- file.path(
-    dirname(exampleData$path_gs),
+    dirname(exampleData$pathGs),
     "stimgate_gate_get_test"
   )
 
-  # Run stimgate_gate first to create the project structure
-  invisible(stimgate_gate(
+  # Run gateStim first to create the project structure
+  invisible(gateStim(
     .data = gs,
     pathProject = pathProject,
     popGate = "root",
@@ -24,8 +24,8 @@ test_that("stimgate_gate_get returns gate table after stimgate_gate", {
     marker = exampleData$marker
   ))
 
-  # Test that stimgate_gate_get function works
-  gateTbl <- stimgate_gate_get(pathProject)
+  # Test that getStimGates function works
+  gateTbl <- getStimGates(pathProject)
 
   # Verify the gate table has expected structure
   expect_true(is.data.frame(gateTbl))
@@ -48,7 +48,7 @@ test_that("stimgate_gate_get returns gate table after stimgate_gate", {
   if (dir.exists(pathProject)) {
     unlink(pathProject, recursive = TRUE)
   }
-  if (dir.exists(exampleData$path_gs)) {
-    unlink(exampleData$path_gs, recursive = TRUE)
+  if (dir.exists(exampleData$pathGs)) {
+    unlink(exampleData$pathGs, recursive = TRUE)
   }
 })

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -1,7 +1,7 @@
 library(testthat)
 exampleData <- getExampleData()
-gs <- flowWorkspace::load_gs(exampleData$path_gs)
-pathProject <- file.path(dirname(exampleData$path_gs), "stimgate")
+gs <- flowWorkspace::load_gs(exampleData$pathGs)
+pathProject <- file.path(dirname(exampleData$pathGs), "stimgate")
 
 # First run gating to create necessary gate data
 invisible(gateStim(
@@ -12,15 +12,15 @@ invisible(gateStim(
   chnl = exampleData$chnl
 ))
 
-test_that("stimgate_plot function exists", {
+test_that("plotStim function exists", {
   # Just test that the function exists and is callable
-  expect_true(exists("stimgate_plot", envir = asNamespace("stimgate")))
-  expect_true(is.function(stimgate_plot))
+  expect_true(exists("plotStim", envir = asNamespace("stimgate")))
+  expect_true(is.function(plotStim))
 })
 
-test_that("stimgate_plot runs", {
+test_that("plotStim runs", {
   # debugonce(.plotGateBv)
-  p <- stimgate_plot(
+  p <- plotStim(
     ind = exampleData$batchList[[1]], # indices in `gs` to plot
     .data = gs, # GatingSet
     pathProject = pathProject,
@@ -30,9 +30,9 @@ test_that("stimgate_plot runs", {
   expect_true(inherits(p, "ggplot"))
 })
 
-test_that("stimgate_plot returns NULL when pList is empty", {
+test_that("plotStim returns NULL when pList is empty", {
   # Test with empty ind list to generate empty pList
-  result <- stimgate_plot(
+  result <- plotStim(
     ind = list(),
     .data = gs,
     pathProject = pathProject,


### PR DESCRIPTION
Fix devtools::check bugs including undocumented parameters, function typos, roxygen example syntax, duplicate function definitions, and outdated API function calls in documentation and test files.

---
*PR created automatically by Jules for task [4775503809444267155](https://jules.google.com/task/4775503809444267155) started by @MiguelRodo*