### PR TITLE
Use first batch element as unstimulated sample in batchList

### DIFF
--- a/R/cyt_pos_gates.R
+++ b/R/cyt_pos_gates.R
@@ -134,7 +134,7 @@
 ) {
   .debug("Getting cyt+ gates for ind: ", ind) # nolint
 
-  # return if ind in batch is the last one, as that is the unstim ind
+  # return if ind in batch is the unstim ind
   if (ind == indUns) {
     return(NULL)
   }

--- a/R/example_data.R
+++ b/R/example_data.R
@@ -131,11 +131,11 @@ getExampleData <- function(
 
   # 5. Build matching batchList mapping
   # simCytExperiment returns sequence as: [Unstim_1, Stim_1, Unstim_2, Stim_2...]
-  # The historical test structure requires the LAST element in a batch vector to be the Unstim index.
+  # The first element in a batch vector is the Unstim index.
   batchList <- lapply(seq_len(nInd), function(i) {
     idxUnstim <- (i - 1) * nCondition + 1
     idxStim <- (i - 1) * nCondition + 2
-    c(idxStim, idxUnstim)
+    c(idxUnstim, idxStim)
   })
 
   # Save cache states

--- a/R/fcs_write.R
+++ b/R/fcs_write.R
@@ -34,7 +34,7 @@
 #'
 #' # Load your GatingSet (gs) and define batch structure
 #' # batchList <- list(batch1 = c(1, 2, 3), batch2 = c(4, 5, 6))
-#' # where the last element in each batch is the unstimulated sample
+#' # where the first element in each batch is the unstimulated sample
 #'
 #' # First, run gating to create gates
 #' pathProject <- tempfile("stimgate_project")
@@ -335,12 +335,12 @@ writeStimFCS <- function(
   indBatchList
 ) {
   indBatchVec <- lapply(indBatchList, function(x) {
-    (x[-length(x)]) |>
+    (x[-1]) |>
       sort() |>
       paste0(collapse = "_")
   }) |>
     unlist()
-  indUnsVec <- lapply(indBatchList, function(x) x[length(x)]) |>
+  indUnsVec <- lapply(indBatchList, function(x) x[[1]]) |>
     unlist()
   indVec <- lapply(seq_len(nrow(gateTbl)), function(x) {
     indMatch <- which(indBatchVec == gateTbl$indStim[[x]])

--- a/R/gate.R
+++ b/R/gate.R
@@ -19,7 +19,7 @@
 #' @param .data GatingSet. A flowWorkspace GatingSet object containing the flow cytometry
 #'   data with both stimulated and unstimulated samples. The GatingSet should have
 #'   consistent channel names across all samples and include proper sample annotations.
-#' @param batchList list. List where each element contains indices of samples belonging to the same batch/donor. Last index per element is the unstimulated vector, e.g. if `batchList = list(1:3, 4:6)`, then indices 3 and 6 correspond to the unstimulated samples for batches 1 and 2, respectively. If `batchList` is named, e.g. `list(pid1 = 1:3, pid2 = 4:6)`, then these names will be used for batch identification.
+#' @param batchList list. List where each element contains indices of samples belonging to the same batch/donor. The first index per element is the unstimulated control sample, e.g. if `batchList = list(c(3, 1, 2), c(6, 4, 5))`, then indices 3 and 6 correspond to the unstimulated samples for batches 1 and 2, respectively. If `batchList` is named, e.g. `list(pid1 = c(3, 1, 2), pid2 = c(6, 4, 5))`, then these names will be used for batch identification.
 #' @param chnl list. List where each element specifies parameters for gating a
 #'   specific channel Each element should be a list containing at minimum the channel
 #'   name (e.g., list(cut = "IL2")). Additional channel-specific parameters can

--- a/R/ind_batch.R
+++ b/R/ind_batch.R
@@ -1,7 +1,7 @@
 #' @title Generate a batch list of sample indices
 #' @description Groups sample rows by batch/donor identifiers, screens out samples 
 #'   falling below a minimum cell count threshold, and structures the output so that 
-#'   the unstimulated control index is always positioned as the final element of each batch.
+#'   the unstimulated control index is always positioned as the first element of each batch.
 #' @param fnTblInfo data.frame. Sample metadata containing annotations.
 #' @param colGrp character vector. One or more column names used to define batches/groups.
 #' @param colStim character. Column name containing stimulation identifiers.
@@ -9,7 +9,7 @@
 #' @param colNCell character. Column name containing the cell count for each sample.
 #' @param minCell numeric. Minimum number of cells required to retain a sample.
 #' @return A named list where each element contains a numeric vector of sample 
-#'   indices representing a batch, with the unstimulated control index at the end.
+#'   indices representing a batch, with the unstimulated control index at the beginning.
 #' @export
 getBatchList <- function(
   fnTblInfo,
@@ -57,10 +57,10 @@ getBatchList <- function(
       fnTblSel[[colStim]] == unsChr
     ]
     
-    # Order so that unstim indices always come last
+    # Order so that unstim indices always come first
     c(
-      setdiff(fnTblSel[["rowNumber"]], rowNumberUns),
-      rowNumberUns
+      rowNumberUns,
+      setdiff(fnTblSel[["rowNumber"]], rowNumberUns)
     )
   }) |>
     stats::setNames(grpVecUnique)

--- a/R/plot_gate.R
+++ b/R/plot_gate.R
@@ -539,7 +539,7 @@ plotStim <- function(
     "init",
     chnl,
     "ind",
-    ind[length(ind)],
+    ind[[1]],
     "bwCpUnsLoc.rds"
   )
   bw <- tryCatch(readRDS(pathBwProject), error = function(e) "nrd0")

--- a/tests/testthat/test-ex.R
+++ b/tests/testthat/test-ex.R
@@ -80,15 +80,15 @@ test_that("getStimExpr applies bias only to unstim sample", {
   saveRDS(chnlLab, file.path(tmp, "metaData", "chnlLab.rds"))
   saveRDS(batchList, file.path(tmp, "metaData", "batchList.rds"))
 
-  # unstim is ind 2 -> expect bias added
-  resUns <- getStimExpr(tmp, ind = "2", bias = TRUE)
-  expect_equal(resUns$BC1, c(7 + 10, 8 + 10))
-  expect_equal(resUns$BC2, c(9 - 2, 10 - 2))
+  # unstim is ind 1 -> expect bias added
+  resUns <- getStimExpr(tmp, ind = "1", bias = TRUE)
+  expect_equal(resUns$BC1, c(1 + 10, 2 + 10, 3 + 10))
+  expect_equal(resUns$BC2, c(4 - 2, 5 - 2, 6 - 2))
 
-  # stim is ind 1 -> bias should not be applied
-  resStim <- getStimExpr(tmp, ind = "1", bias = TRUE)
-  expect_equal(resStim$BC1, c(1, 2, 3))
-  expect_equal(resStim$BC2, c(4, 5, 6))
+  # stim is ind 2 -> bias should not be applied
+  resStim <- getStimExpr(tmp, ind = "2", bias = TRUE)
+  expect_equal(resStim$BC1, c(7, 8))
+  expect_equal(resStim$BC2, c(9, 10))
 })
 
 test_that("getStimExpr excludes minimum observed values when excMin = TRUE", {

--- a/tests/testthat/test-ind_batch_order.R
+++ b/tests/testthat/test-ind_batch_order.R
@@ -1,0 +1,33 @@
+test_that("getBatchList positions unstimulated sample index first", {
+  fnTblInfo <- data.frame(
+    PID = c("P1", "P1", "P2", "P2"),
+    Stim = c("SEB", "UNS", "UNS", "PMA"),
+    NCells = c(1000, 1000, 1000, 1000),
+    stringsAsFactors = FALSE
+  )
+
+  batchList <- getBatchList(
+    fnTblInfo = fnTblInfo,
+    colGrp = "PID",
+    colStim = "Stim",
+    unsChr = "UNS",
+    colNCell = "NCells",
+    minCell = 100
+  )
+
+  expect_named(batchList, c("P1", "P2"))
+  # Batch P1: UNS is row 2, SEB is row 1 -> expected c(2, 1)
+  expect_equal(batchList$P1, c(2, 1))
+  # Batch P2: UNS is row 3, PMA is row 4 -> expected c(3, 4)
+  expect_equal(batchList$P2, c(3, 4))
+})
+
+test_that("getExampleData positions unstimulated sample index first in batchList", {
+  exampleData <- getExampleData(nInd = 2)
+  expect_type(exampleData$batchList, "list")
+  expect_equal(length(exampleData$batchList), 2)
+  # For index 1: idxUnstim = 1, idxStim = 2 -> c(1, 2)
+  expect_equal(exampleData$batchList[[1]], c(1, 2))
+  # For index 2: idxUnstim = 3, idxStim = 4 -> c(3, 4)
+  expect_equal(exampleData$batchList[[2]], c(3, 4))
+})


### PR DESCRIPTION
Update getBatchList(), getExampleData(), gateStim(), fcs_write, plot_gate, documentation, and tests to consistently position the unstimulated sample index as the first element of each batch list vector.

---
*PR created automatically by Jules for task [4711977491249204932](https://jules.google.com/task/4711977491249204932) started by @MiguelRodo*