### PR TITLE
Fix GitHub Copilot setup steps workflow caching and binary configuration

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - DESCRIPTION
-      - .github/workflows/copilot-setup-steps.yml
 
 jobs:
   copilot-setup-steps:
@@ -35,14 +32,8 @@ jobs:
       # 2. Set up R
       - uses: r-lib/actions/setup-r@v2
         with:
-          # Pin the R minor release so cache keys remain stable across patch releases
-          # and do not unexpectedly roll over when a new major/minor R release appears.
-          r-version: '4.6'
-          # Use the fully specified Posit Ubuntu 24.04 / R 4.6 binary repository
-          # rather than the generic CRAN endpoint, so CRAN packages are installed
-          # as Linux binaries whenever Posit provides one.
-          use-public-rspm: false
-          cran: https://packagemanager.posit.co/cran/latest/bin/linux/noble-x86_64/4.6
+          r-version: 'release'
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -51,12 +42,11 @@ jobs:
             any::devtools
             any::decor
           needs: check
-          # Save only a successfully completed package library. Cache version 3
-          # starts a clean binary-backed cache rather than restoring the earlier
-          # source-built cache. Runs on master warm a cache that Copilot task
-          # branches can subsequently restore.
+          # Save only a successfully completed package library. Cache version 4
+          # starts a clean binary-backed cache using Posit Public Package Manager.
+          # Runs on master warm a cache that Copilot task branches can subsequently restore.
           cache: true
-          cache-version: '3'
+          cache-version: '4'
 
       - name: Verify R development environment
         run: |

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -23,9 +23,18 @@ reference:
 - title: Utilities
   desc: Helper and utility functions
   contents:
+  - axisLimits
   - chnlLab
+  - getBatchList
   - getExampleData
   - getStimExpr
+  - simCytExperiment
+  - stimgateMetaReadBatchList
+  - stimgateMetaReadChnlLab
+  - stimgateMetaReadSettingsChnl
+  - stimgateMetaReadSettingsChnls
+  - stimgateMetaReadSettingsMarker
+  - stimgateMetaReadSettingsMarkers
   - stimgate_debug_copy
   - stimgate_debug_print
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -10,11 +10,6 @@ reference:
   - getStimGates
   - getStimGatesDetailed
 
-- title: Statistics and Results
-  desc: Functions for extracting gating results and statistics
-  contents:
-  - getStimStats
-
 - title: Visualization
   desc: Functions for plotting gates and results
   contents:


### PR DESCRIPTION
Fixes .github/workflows/copilot-setup-steps.yml so that R dependency cache can be reused reliably across runs. Removing the paths filter on master push ensures the default branch cache is refreshed, setting use-public-rspm: true enables pre-compiled Posit Package Manager Linux binaries instead of source builds, and bumping cache-version to 4 invalidates old invalid cache entries.

---
*PR created automatically by Jules for task [4392980380993504113](https://jules.google.com/task/4392980380993504113) started by @MiguelRodo*