### PR TITLE
Guard optional example dependencies and update CI check config

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,6 +27,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      _R_CHECK_FORCE_SUGGESTS_: false
 
     steps:
       - uses: actions/checkout@v4

--- a/R/gate.R
+++ b/R/gate.R
@@ -304,13 +304,15 @@
 #' )
 #'
 #' # Create plots
-#' plots <- plotStim(
-#'   ind = exampleData$batchList[[1]], # indices in `gs` to plot
-#'   .data = gs, # GatingSet
-#'   pathProject = pathProject,
-#'   marker = exampleData$marker,
-#'   grid = TRUE
-#' )
+#' if (requireNamespace("hexbin", quietly = TRUE)) {
+#'   plots <- plotStim(
+#'     ind = exampleData$batchList[[1]], # indices in `gs` to plot
+#'     .data = gs, # GatingSet
+#'     pathProject = pathProject,
+#'     marker = exampleData$marker,
+#'     grid = TRUE
+#'   )
+#' }
 #' @importFrom flowCore exprs<- parameters<-
 #' @importFrom stats approx as.formula binomial density glm kmeans median optim predict quantile rnorm sd dnorm fft
 #' @importFrom utils read.csv write.csv

--- a/R/plot_gate.R
+++ b/R/plot_gate.R
@@ -65,13 +65,15 @@
 #' )
 #'
 #' # Create plots
-#' plots <- plotStim(
-#'   ind = exampleData$batchList[[1]], # indices in `gs` to plot
-#'   .data = gs, # GatingSet
-#'   pathProject = pathProject,
-#'   marker = exampleData$marker,
-#'   grid = TRUE
-#' )
+#' if (requireNamespace("hexbin", quietly = TRUE)) {
+#'   plots <- plotStim(
+#'     ind = exampleData$batchList[[1]], # indices in `gs` to plot
+#'     .data = gs, # GatingSet
+#'     pathProject = pathProject,
+#'     marker = exampleData$marker,
+#'     grid = TRUE
+#'   )
+#' }
 #' @export
 plotStim <- function(
   ind,

--- a/man/gateStim.Rd
+++ b/man/gateStim.Rd
@@ -431,13 +431,15 @@ gateStim(
 )
 
 # Create plots
-plots <- plotStim(
-  ind = exampleData$batchList[[1]], # indices in `gs` to plot
-  .data = gs, # GatingSet
-  pathProject = pathProject,
-  marker = exampleData$marker,
-  grid = TRUE
-)
+if (requireNamespace("hexbin", quietly = TRUE)) {
+  plots <- plotStim(
+    ind = exampleData$batchList[[1]], # indices in `gs` to plot
+    .data = gs, # GatingSet
+    pathProject = pathProject,
+    marker = exampleData$marker,
+    grid = TRUE
+  )
+}
 }
 \seealso{
 \code{\link{getStimGates}} for extracting gate information,

--- a/man/plotStim.Rd
+++ b/man/plotStim.Rd
@@ -133,11 +133,13 @@ gateStim(
 )
 
 # Create plots
-plots <- plotStim(
-  ind = exampleData$batchList[[1]], # indices in `gs` to plot
-  .data = gs, # GatingSet
-  pathProject = pathProject,
-  marker = exampleData$marker,
-  grid = TRUE
-)
+if (requireNamespace("hexbin", quietly = TRUE)) {
+  plots <- plotStim(
+    ind = exampleData$batchList[[1]], # indices in `gs` to plot
+    .data = gs, # GatingSet
+    pathProject = pathProject,
+    marker = exampleData$marker,
+    grid = TRUE
+  )
+}
 }


### PR DESCRIPTION
This change adds explicit guards for optional suggested package dependencies (hexbin) in plotStim roxygen example blocks and generated documentation files. It also updates R-CMD-check.yaml with _R_CHECK_FORCE_SUGGESTS_: false to ensure proper dependency handling during CI package checks without modifying any gating algorithm code.

---
*PR created automatically by Jules for task [8886522163692130521](https://jules.google.com/task/8886522163692130521) started by @MiguelRodo*