### PR TITLE
Fix R CMD check package metadata, documentation and namespace diagnostics (#192)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,6 +14,9 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^README\.html$
+^analysis/
+^analysis$
 
 # Start of projr section: do not edit by hand (update with projr_ignore_auto())
 ^docs/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,8 +17,8 @@ Roxygen: list(markdown = TRUE)
 biocViews: FlowCytometry, SingleCell, CellBasedAssays, ImmunoOncology
 VignetteBuilder: knitr
 Imports: cowplot, dplyr, ggplot2, purrr, rlang, stringr, tibble, tidyr,
-        scam, mgcv, ks, gtools, splines, stats, utils, flowCore,
-        flowWorkspace, cluster, cpp11, MASS
+        scam, ks, gtools, splines, stats, utils, flowCore,
+        flowWorkspace, cluster, cpp11, MASS, Biobase, mvtnorm
 LinkingTo: cpp11
 Suggests: testthat (>= 3.0.0), HDCytoData, here, BiocManager, knitr,
         rmarkdown, hexbin, gh, gitcreds

--- a/R/UtilsGGSV-axis_limits.R
+++ b/R/UtilsGGSV-axis_limits.R
@@ -204,6 +204,9 @@ axisLimits <- function(p, limitsExpand = NULL, limitsEqual = FALSE) {
   p
 }
 
+#' @param limits_expand list or NULL Alias for `limitsExpand`. Default is NULL.
+#' @param limits_equal logical Alias for `limitsEqual`. Default is FALSE.
+#'
 #' @rdname axisLimits
 #' @export
 axis_limits <- function(p, limits_expand = NULL, limits_equal = FALSE) {

--- a/R/bw_norm_helpers.R
+++ b/R/bw_norm_helpers.R
@@ -1475,7 +1475,7 @@
     scam::scam(
       logDens ~ s(x, bs = "mpd", k = k, m = c(2, 1)),
       data = fitTblThin,
-      family = gaussian(),
+      family = stats::gaussian(),
       control = scam::scam.control(
         print.warn = FALSE,
         trace = FALSE,

--- a/R/cp_uns_loc_density.R
+++ b/R/cp_uns_loc_density.R
@@ -892,7 +892,7 @@
   x <- x[ord]
   y <- y[ord]
 
-  sum(diff(x) * (head(y, -1L) + tail(y, -1L)) / 2)
+  sum(diff(x) * (utils::head(y, -1L) + utils::tail(y, -1L)) / 2)
 }
 
 #' @keywords internal
@@ -1219,21 +1219,21 @@
 
   # Find the threshold index
   valid_idx <- probTbl |>
-    dplyr::arrange(xStim) |>
+    dplyr::arrange(.data$xStim) |>
     dplyr::mutate(
-      ge_0025 = probStimNorm >= 0.025,
-      ge_0075 = probStimNorm >= 0.075,
+      ge_0025 = .data$probStimNorm >= 0.025,
+      ge_0075 = .data$probStimNorm >= 0.075,
       n_remaining = rev(seq_len(dplyr::n())),
 
       # Calculate tail proportions
-      prop_0025 = rev(cumsum(rev(ge_0025))) / n_remaining,
-      prop_0075 = rev(cumsum(rev(ge_0075))) / n_remaining,
+      prop_0025 = rev(cumsum(rev(.data$ge_0025))) / .data$n_remaining,
+      prop_0075 = rev(cumsum(rev(.data$ge_0075))) / .data$n_remaining,
 
       # Do both conditions match?
-      both_met = prop_0025 >= 0.90 & prop_0075 >= 0.25
+      both_met = .data$prop_0025 >= 0.90 & .data$prop_0075 >= 0.25
     ) |>
     # Get the row index of the first time this becomes true
-    dplyr::pull(both_met) |>
+    dplyr::pull(.data$both_met) |>
     which() |>
     which.min()
 

--- a/R/cp_uns_loc_derivative.R
+++ b/R/cp_uns_loc_derivative.R
@@ -145,7 +145,7 @@
   }
 }
 
-#' Extract finite fitted probabilities on [0, 1]
+#' Extract finite fitted probabilities on \code{[0, 1]}
 #' @keywords internal
 .getCpUnsLocProbability <- function(dataMod, probCol) {
   prob <- suppressWarnings(as.numeric(dataMod[[probCol]]))
@@ -259,8 +259,8 @@
   deriv[!is.finite(deriv)] <- 0
 
   tibble::tibble(
-    x = (head(probTbl$x, -1L) + tail(probTbl$x, -1L)) / 2,
-    prob = (head(probTbl$prob, -1L) + tail(probTbl$prob, -1L)) / 2,
+    x = (utils::head(probTbl$x, -1L) + utils::tail(probTbl$x, -1L)) / 2,
+    prob = (utils::head(probTbl$prob, -1L) + utils::tail(probTbl$prob, -1L)) / 2,
     deriv = deriv,
     source = "model_probability_finite_difference"
   )

--- a/R/fcs_write.R
+++ b/R/fcs_write.R
@@ -418,7 +418,7 @@ writeStimFCS <- function(
     ex = ex,
     gateTblInd = gateTblInd,
     mult = mult,
-    chnl = chnl,
+    chnlGate = chnl,
     gateTypeCytPos = gateTypeCytPos,
     gateTypeSinglePos = gateTypeSinglePos
   )
@@ -432,7 +432,7 @@ writeStimFCS <- function(
     ex = ex,
     combnExc = combnExc,
     gateTblInd = gateTblInd,
-    chnl = chnl,
+    chnlGate = chnl,
     gateTypeCytPos = gateTypeCytPos,
     gateTypeSinglePos = gateTypeSinglePos
   )

--- a/R/functionsForBenchmarking-Cyt.R
+++ b/R/functionsForBenchmarking-Cyt.R
@@ -2,7 +2,7 @@
 #'
 #' @keywords internal
 .posDef <- function(n, covEvMin = 1, covEvMax = 2) {
-  ev <- runif(n, min = covEvMin, max = covEvMax)
+  ev <- stats::runif(n, min = covEvMin, max = covEvMax)
   if (n == 1) {
     return(matrix(ev, 1, 1))
   }
@@ -253,6 +253,8 @@
 #'   perturbations added to cluster means within each sample. Default is 0.
 #' @param clusterPerturbationSd Numeric. Standard deviation of cluster-level
 #'   perturbations applied during cell-level simulation. Default is 0.
+#' @param covEvMin Numeric. Minimum eigenvalue for cluster covariance matrices. Default is 1.
+#' @param covEvMax Numeric. Maximum eigenvalue for cluster covariance matrices. Default is 2.
 #
 #' @return A list with two elements:
 #'   - `flowFrameList`: A named list of `flowCore::flowFrame` objects.

--- a/man/axisLimits.Rd
+++ b/man/axisLimits.Rd
@@ -25,6 +25,10 @@ Default is NULL.}
 \item{limitsEqual}{logical If TRUE, then the ranges on the x- and
 y-axes must be equal. Effectively applied after expand_grid is
 applied. Default is FALSE.}
+
+\item{limits_expand}{list or NULL Alias for \code{limitsExpand}. Default is NULL.}
+
+\item{limits_equal}{logical Alias for \code{limitsEqual}. Default is FALSE.}
 }
 \value{
 A ggplot object with adjusted axis limits.

--- a/man/dot-getCpUnsLocProbability.Rd
+++ b/man/dot-getCpUnsLocProbability.Rd
@@ -2,11 +2,11 @@
 % Please edit documentation in R/cp_uns_loc_derivative.R
 \name{.getCpUnsLocProbability}
 \alias{.getCpUnsLocProbability}
-\title{Extract finite fitted probabilities on \link{0, 1}}
+\title{Extract finite fitted probabilities on \code{[0, 1]}}
 \usage{
 .getCpUnsLocProbability(dataMod, probCol)
 }
 \description{
-Extract finite fitted probabilities on \link{0, 1}
+Extract finite fitted probabilities on \code{[0, 1]}
 }
 \keyword{internal}

--- a/man/getStimGates.Rd
+++ b/man/getStimGates.Rd
@@ -35,6 +35,6 @@ pathProject <- gateStim(
   popGate = "root"
 )
 
-# Get statistics for the identified gates
+# Get identified gates
 gates <- getStimGates(pathProject)
 }

--- a/man/getStimStats.Rd
+++ b/man/getStimStats.Rd
@@ -13,5 +13,5 @@ getStimStats(pathProject)
 A data frame with gating statistics.
 }
 \description{
-Get gating statistics
+Read and return gating statistics computed during gating.
 }

--- a/man/simCytExperiment.Rd
+++ b/man/simCytExperiment.Rd
@@ -66,6 +66,10 @@ perturbations added to cluster means within each sample. Default is 0.}
 
 \item{clusterPerturbationSd}{Numeric. Standard deviation of cluster-level
 perturbations applied during cell-level simulation. Default is 0.}
+
+\item{covEvMin}{Numeric. Minimum eigenvalue for cluster covariance matrices. Default is 1.}
+
+\item{covEvMax}{Numeric. Maximum eigenvalue for cluster covariance matrices. Default is 2.}
 }
 \value{
 A list with two elements:


### PR DESCRIPTION
Address non-algorithmic R CMD check findings without altering StimGate thresholding or gating behaviour:
- Declare Biobase and mvtnorm in DESCRIPTION Imports, remove unused mgcv.
- Explicitly qualify stats::gaussian, stats::runif, utils::head, and utils::tail calls.
- Fix tidy evaluation data-masking pronoun references (.data$) in R/cp_uns_loc_density.R.
- Update roxygen documentation to escape [0, 1] link targets in R/cp_uns_loc_derivative.R, document limits_expand and limits_equal in R/UtilsGGSV-axis_limits.R, and document covEvMin and covEvMax in R/functionsForBenchmarking-Cyt.R. Regenerate .Rd files.
- Exclude README.html and analysis/ from built package contents in .Rbuildignore.
- Fix partial argument match call warning in .fcsWriteImpl by passing chnlGate explicitly.

---
*PR created automatically by Jules for task [1354196816549441178](https://jules.google.com/task/1354196816549441178) started by @MiguelRodo*