### PR TITLE
Fix project population discovery and plotting guards

### DIFF
--- a/R/ex.R
+++ b/R/ex.R
@@ -428,12 +428,13 @@ getStimExpr <- function(
 #' @keywords internal
 .getExProjectPop <- function(pathProject) {
   .assertString(pathProject)
-  popVec <- list.dirs(
-    file.path(pathProject, "sampleData"),
-    recursive = FALSE
-  ) |>
-    basename() |>
-    sub("^pop_(.*)$", "\\1", x = _)
+  pathDir <- file.path(pathProject, "sampleData")
+  if (!dir.exists(pathDir)) {
+    return(character(0))
+  }
+  dirVec <- list.dirs(pathDir, full.names = FALSE, recursive = FALSE)
+  dirVec <- dirVec[nzchar(dirVec) & grepl("^pop_", dirVec)]
+  popVec <- unique(sub("^pop_", "", dirVec))
   .assertStringVector(popVec)
   popVec
 }
@@ -443,12 +444,13 @@ getStimExpr <- function(
   pop <- pop %||% .getExProjectPop(pathProject)
   pop <- pop[[1]]
   .assertString(pop)
-  indVec <- list.dirs(
-    file.path(pathProject, "sampleData", paste0("pop_", pop)),
-    recursive = FALSE
-  ) |>
-    basename() |>
-    sub("^ind_", "", x = _)
+  pathDir <- file.path(pathProject, "sampleData", paste0("pop_", pop))
+  if (!dir.exists(pathDir)) {
+    return(character(0))
+  }
+  dirVec <- list.dirs(pathDir, full.names = FALSE, recursive = FALSE)
+  dirVec <- dirVec[nzchar(dirVec) & grepl("^ind_", dirVec)]
+  indVec <- unique(sub("^ind_", "", dirVec))
   .assertStringVector(indVec)
   indVec
 }
@@ -468,8 +470,12 @@ getStimExpr <- function(
     paste0("ind_", ind)
   )
   .assertString(pathChnlDir)
-  chnlVec <- list.files(pathChnlDir) |>
-    sub("^chnl_(.*)\\.rds$", "\\1", x = _)
+  if (!dir.exists(pathChnlDir)) {
+    return(character(0))
+  }
+  fnVec <- list.files(pathChnlDir)
+  fnVec <- fnVec[grepl("^chnl_.*\\.rds$", fnVec)]
+  chnlVec <- unique(sub("^chnl_(.*)\\.rds$", "\\1", fnVec))
   .assertStringVector(chnlVec)
   chnlVec
 }

--- a/R/gates.R
+++ b/R/gates.R
@@ -67,7 +67,8 @@ getStimGates <- function(
     return(character(0))
   }
   dirVec <- list.dirs(pathDir, full.names = FALSE, recursive = FALSE)
-  popVec <- unique(sub("^pop(.*)$", "\\1", dirVec))
+  dirVec <- dirVec[nzchar(dirVec) & grepl("^pop", dirVec)]
+  popVec <- unique(sub("^pop", "", dirVec))
   popVec
 }
 
@@ -78,7 +79,8 @@ getStimGates <- function(
     return(character(0))
   }
   dirVec <- list.dirs(pathDir, full.names = FALSE, recursive = FALSE)
-  chnlVec <- unique(sub("^chnl(.*)$", "\\1", dirVec))
+  dirVec <- dirVec[nzchar(dirVec) & grepl("^chnl", dirVec)]
+  chnlVec <- unique(sub("^chnl", "", dirVec))
   chnlVec
 }
 

--- a/R/plot_gate.R
+++ b/R/plot_gate.R
@@ -103,7 +103,7 @@ plotStim <- function(
   if (is.null(marker) && is.null(chnl)) {
     stop("Must specify one of marker or chnl")
   }
-  pop <- pop %% setdiff(.gateGetPop(pathProject), "")
+  pop <- pop %|c|% .gateGetPop(pathProject)
   if (length(pop) > 1L) {
     stop("Cannot plot gates for multiple populations")
   }
@@ -535,15 +535,26 @@ plotStim <- function(
   mult,
   gateUnsMethod
 ) {
-  pathBwProject <- file.path(
-    pathProject,
-    "intermediateData",
-    "init",
-    chnl,
-    "ind",
-    ind[[1]],
-    "bwCpUnsLoc.rds"
+  if (length(ind) == 0L) {
+    return(NULL)
+  }
+  chnl <- chnl %||% tryCatch(
+    stimgateMetaReadMarkerLab(pathProject)[marker],
+    error = function(e) NULL
   )
+  pathBwProject <- if (!is.null(chnl)) {
+    file.path(
+      pathProject,
+      "intermediateData",
+      "init",
+      chnl,
+      "ind",
+      ind[[1]],
+      "bwCpUnsLoc.rds"
+    )
+  } else {
+    ""
+  }
   bw <- tryCatch(readRDS(pathBwProject), error = function(e) "nrd0")
   plotTbl <- .plotGateUvMarkerGetPlotTbl(
     marker = marker,

--- a/tests/testthat/test-project-discovery.R
+++ b/tests/testthat/test-project-discovery.R
@@ -1,0 +1,50 @@
+test_that(".gateGetPop and .gateGetChnl handle single and multiple populations correctly", {
+  tmpProj <- file.path(tempdir(), paste0("proj_disc_test_", as.numeric(Sys.time())))
+  dir.create(file.path(tmpProj, "gates", "poproot", "chnlBC1"), recursive = TRUE)
+  dir.create(file.path(tmpProj, "gates", "poproot", "chnlBC2"), recursive = TRUE)
+
+  expect_equal(.gateGetPop(tmpProj), "root")
+  expect_equal(sort(.gateGetChnl(tmpProj, "root")), c("BC1", "BC2"))
+
+  dir.create(file.path(tmpProj, "gates", "popCD4"), recursive = TRUE)
+  expect_equal(sort(.gateGetPop(tmpProj)), c("CD4", "root"))
+
+  unlink(tmpProj, recursive = TRUE)
+})
+
+test_that(".getExProjectPop, .getExProjectInd and .getExProjectChnl discover sampleData correctly", {
+  tmpProj <- file.path(tempdir(), paste0("sample_disc_test_", as.numeric(Sys.time())))
+  dir.create(file.path(tmpProj, "sampleData", "pop_root", "ind_1"), recursive = TRUE)
+  dir.create(file.path(tmpProj, "sampleData", "pop_root", "ind_2"), recursive = TRUE)
+  saveRDS(1:5, file.path(tmpProj, "sampleData", "pop_root", "ind_1", "chnl_BC1.rds"))
+
+  expect_equal(.getExProjectPop(tmpProj), "root")
+  expect_equal(sort(.getExProjectInd(tmpProj, "root")), c("1", "2"))
+  expect_equal(.getExProjectChnl(tmpProj, "root", "1"), "BC1")
+
+  unlink(tmpProj, recursive = TRUE)
+})
+
+test_that("plotStim error handling for multiple populations and empty inputs", {
+  tmpProj <- file.path(tempdir(), paste0("plot_disc_test_", as.numeric(Sys.time())))
+  dir.create(file.path(tmpProj, "gates", "poproot"), recursive = TRUE)
+  dir.create(file.path(tmpProj, "gates", "popCD4"), recursive = TRUE)
+
+  expect_error(plotStim(ind = c(1, 2), .data = NULL, pathProject = tmpProj, marker = "IL2"),
+               "Cannot plot gates for multiple populations")
+
+  unlink(tmpProj, recursive = TRUE)
+
+  tmpProjEmpty <- file.path(tempdir(), paste0("plot_disc_empty_", as.numeric(Sys.time())))
+  expect_error(plotStim(ind = c(1, 2), .data = NULL, pathProject = tmpProjEmpty, marker = "IL2"),
+               "No population found for plotting gates")
+
+  expect_null(.plotGateUvMarker(marker = "IL2", chnl = "BC1", pop = "root", ind = numeric(0),
+                                 .data = NULL, excMin = FALSE, indLab = NULL, axisLab = NULL,
+                                 showGate = FALSE, pathProject = tmpProjEmpty, minCell = 10,
+                                 bias = FALSE, combnExc = NULL, chnlGate = NULL, markerGate = NULL,
+                                 gateTypeCytPos = "cyt", gateTypeSinglePos = "single", mult = FALSE,
+                                 gateUnsMethod = "min"))
+
+  unlink(tmpProjEmpty, recursive = TRUE)
+})


### PR DESCRIPTION
Fixes project directory discovery helpers, plotStim population resolution, and empty index plotting guards.

---
*PR created automatically by Jules for task [12908474802614293743](https://jules.google.com/task/12908474802614293743) started by @MiguelRodo*