### PR TITLE
Remove HDCytoData and flowWorkspaceData unused dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Bioconductor dependencies explicitly:
 if (!requireNamespace("BiocManager", quietly = TRUE)) {
   install.packages("BiocManager")
 }
-BiocManager::install(c("flowCore", "flowWorkspace", "HDCytoData"))
+BiocManager::install(c("flowCore", "flowWorkspace"))
 ```
 
 ### GitHub Copilot cloud agent

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,6 @@ Imports: cowplot, dplyr, ggplot2, purrr, rlang, stringr, tibble, tidyr,
         scam, ks, gtools, splines, stats, utils, flowCore,
         flowWorkspace, cluster, cpp11, MASS, Biobase, mvtnorm
 LinkingTo: cpp11
-Suggests: testthat (>= 3.0.0), HDCytoData, here, BiocManager, knitr,
+Suggests: testthat (>= 3.0.0), here, BiocManager, knitr,
         rmarkdown, hexbin, gh, gitcreds
 Config/roxygen2/version: 8.1.0

--- a/_dependencies.R
+++ b/_dependencies.R
@@ -1,6 +1,4 @@
 library(devtools)
-library(HDCytoData)
-library(flowWorkspaceData)
 library(styler)
 library(lintr)
 library(BiocCheck)

--- a/tests/testthat/test-coverage-gaps.R
+++ b/tests/testthat/test-coverage-gaps.R
@@ -58,7 +58,6 @@ test_that("stimgateGateRunsWithGateCombnPrejoin", {
 test_that("stimgateGateRunsWithGateCombnNo", {
   skip_if_not_installed("flowWorkspace")
   skip_if_not_installed("flowCore")
-  skip_if_not_installed("HDCytoData")
 
   # Get example data
   exampleData <- stimgate::getExampleData()
@@ -88,7 +87,6 @@ test_that("stimgateGateRunsWithGateCombnNo", {
 test_that("stimgateGateRunsWithGateCombnMedian", {
   skip_if_not_installed("flowWorkspace")
   skip_if_not_installed("flowCore")
-  skip_if_not_installed("HDCytoData")
 
   # Get example data
   exampleData <- stimgate::getExampleData()
@@ -118,7 +116,6 @@ test_that("stimgateGateRunsWithGateCombnMedian", {
 test_that("stimgateGateRunsWithGateCombnMax", {
   skip_if_not_installed("flowWorkspace")
   skip_if_not_installed("flowCore")
-  skip_if_not_installed("HDCytoData")
 
   # Get example data
   exampleData <- stimgate::getExampleData()


### PR DESCRIPTION
Removed HDCytoData and flowWorkspaceData references from _dependencies.R, DESCRIPTION, AGENTS.md, and tests without modifying renv files.

---
*PR created automatically by Jules for task [16500303527815465200](https://jules.google.com/task/16500303527815465200) started by @MiguelRodo*