### PR TITLE
Update AGENTS.md regarding ggplot2 import directive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,9 @@ unstimulated background.
 
 - Use `@import` or `@importFrom` directives in roxygen comments; explicitly
   qualify all package calls with `pkg::fun()`. The only exceptions are
-  `ggplot2` functions and `flowCore::exprs`, which may be called without a
-  namespace qualifier and do not require `@importFrom` tags.
+  `ggplot2` (imported wholesale via `#' @import ggplot2` in `R/misc.R`) and
+  `flowCore::exprs`, which may be called without a namespace qualifier and do
+  not require `@importFrom` tags.
 - Modify `.Rd` files manually; regenerate them with `devtools::document()`.
 - Use `return()` as the last line of a function; use it only for early returns.
 - Add `library()` calls inside test files.
@@ -276,8 +277,9 @@ pkgdown::check_pkgdown()
 ### Package Namespace
 
 - Reference all external functions explicitly as `pkg::fun()`.
-- Exceptions: `ggplot2` functions and `flowCore::exprs` may be called without a
-  namespace qualifier and do not require `@importFrom` tags.
+- Exceptions: `ggplot2` is imported wholesale via `#' @import ggplot2` in
+  `R/misc.R`, so `ggplot2` functions and `flowCore::exprs` may be called without
+  a namespace qualifier and do not require `@importFrom` tags.
 
 ---
 


### PR DESCRIPTION
Updated `AGENTS.md` in Sections 2 and 6 to accurately document that `ggplot2` is imported wholesale via `#' @import ggplot2` in `R/misc.R`, removing the previous contradiction and clarifying namespace qualifying conventions.

---
*PR created automatically by Jules for task [460647619364593052](https://jules.google.com/task/460647619364593052) started by @MiguelRodo*