### PR TITLE
Align tailgate comparison code and documentation on cytoUtils

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,14 +292,14 @@ pkgdown::check_pkgdown()
    `stimgate_cpPmden()` compiled via `cpp11` (`src/stimgate_cppmden.cpp` and `src/cpPmden.cpp`).
 2. **Comparison code vs. package code**:
    `R/` contains only StimGate implementation code. Benchmark comparisons against
-   the legacy `openCyto` tailgate call `openCyto:::.cytokineCutpoint()` from the
-   `openCyto` package directly in `scripts/r/sim-compare-freq_bs.R` and
+   the tailgate method call `cytoUtils:::.cytokine_cutpoint()` from the
+   `cytoUtils` package directly in `scripts/r/sim-compare-freq_bs.R` and
    `analysis/7-sim-compare-freq_bs.qmd`. Note that `R/functionsForBenchmarking-Cyt.R`
    is an exception: it stays in `R/` because `getExampleData()` (an exported function)
    calls `simCytExperiment()` internally.
 3. **Legacy comparator policy**:
-   Tailgate comparator functions are invoked directly from the `openCyto` package via
-   `openCyto:::.cytokineCutpoint()`. Do not reintroduce vendored legacy tailgate helpers
+   Tailgate comparator functions are invoked directly from the `cytoUtils` package via
+   `cytoUtils:::.cytokine_cutpoint()`. Do not reintroduce vendored legacy tailgate helpers
    under `scripts/r/` or `R/`.
 4. **Audit status for `.getCpTg()` migration (issue #157/#158)**:
    Remaining call sites are catalogued by `.get_cp_tg_call_audit()` and summarised by

--- a/R/cp_uns_loc_filtering.R
+++ b/R/cp_uns_loc_filtering.R
@@ -1070,7 +1070,7 @@
 #' the first point at which the density has flattened to the requested fraction
 #' of that slope. This relative-derivative rule preserves the local-FDR shape
 #' threshold behaviour and deliberately does not use a fixed absolute tolerance
-#' like the legacy .cytokineCutpoint() `tol` gate.
+#' like the cytoUtils:::.cytokine_cutpoint() `tol` gate.
 #'
 #' @keywords internal
 .getStimGateTailgate <- function(density, peakX = NULL, fraction = 1 / 200) {

--- a/man/dot-getStimGateTailgate.Rd
+++ b/man/dot-getStimGateTailgate.Rd
@@ -12,6 +12,6 @@ locate the steepest negative derivative on the descending shoulder and report
 the first point at which the density has flattened to the requested fraction
 of that slope. This relative-derivative rule preserves the local-FDR shape
 threshold behaviour and deliberately does not use a fixed absolute tolerance
-like the legacy .cytokineCutpoint() \code{tol} gate.
+like the cytoUtils:::.cytokine_cutpoint() \code{tol} gate.
 }
 \keyword{internal}

--- a/scripts/r/sim-compare-freq_bs.R
+++ b/scripts/r/sim-compare-freq_bs.R
@@ -241,7 +241,7 @@
 
 #' Call the cytoUtils tailgate implementation
 #'
-#' If bandwidth is NULL, cytoUtils:::.cytokineCutpoint() forwards NULL to
+#' If bandwidth is NULL, cytoUtils:::.cytokine_cutpoint() forwards NULL to
 #' cytoUtils:::.deriv_density(), whose default behaviour is to estimate the
 #' bandwidth with ks::hpi().
 #'


### PR DESCRIPTION
Updated AGENTS.md, scripts/r/sim-compare-freq_bs.R, R/cp_uns_loc_filtering.R, and man/dot-getStimGateTailgate.Rd to consistently identify cytoUtils:::.cytokine_cutpoint() as the source of the tailgate comparator and remove stale openCyto references.

---
*PR created automatically by Jules for task [11375811285624753621](https://jules.google.com/task/11375811285624753621) started by @MiguelRodo*