### PR TITLE
Remove calcSinglePosGates plumbing from analysis helpers

### DIFF
--- a/scripts/r/sim-bandwidth.R
+++ b/scripts/r/sim-bandwidth.R
@@ -346,8 +346,7 @@
   locMarginalRefQuantile = 0.75,
   locTolRefPeak = "highest",
   gateCombn = "min",
-  calcCytPosGates = FALSE,
-  calcSinglePosGates = FALSE
+  calcCytPosGates = FALSE
 ) {
   bwMtdGate <- .simBandwidthAdaptiveBwMtd(
     bwMtd = bwMtd,
@@ -435,7 +434,6 @@
       batchList = batchList,
       marker = paste0("MarkerF", seq_len(nMarker)),
       calcCytPosGates = calcCytPosGates,
-      calcSinglePosGates = calcSinglePosGates,
       biasUns = biasUns,
       bw = bw,
       bwAdaptive = bwAdaptive,

--- a/scripts/r/sim-bw-adaptive.R
+++ b/scripts/r/sim-bw-adaptive.R
@@ -817,7 +817,6 @@
       batchList = batch_list,
       marker = paste0("MarkerF", seq_len(nMarker)),
       calcCytPosGates = calc_cyt_pos_gates,
-      calcSinglePosGates = calc_single_pos_gates,
       biasUns = bias_uns,
       bw = bw_setting,
       bwFallback = if (!is.null(bw_setting)) bw_setting else "auto",

--- a/scripts/r/sim-compare-freq_bs.R
+++ b/scripts/r/sim-compare-freq_bs.R
@@ -622,7 +622,6 @@
   gateCombn = "min",
   tolClust = NULL,
   calcCytPosGates = FALSE,
-  calcSinglePosGates = FALSE,
   includeLocCondition = TRUE
 ) {
   truthTbl <- .simCompareTruthTable(
@@ -658,7 +657,6 @@
         batchList = batchList,
         marker = paste0("MarkerF", seq_len(nMarker)),
         calcCytPosGates = calcCytPosGates,
-        calcSinglePosGates = calcSinglePosGates,
         biasUns = biasUns,
         bw = bw,
         bwFallback = bwFallback,
@@ -841,7 +839,6 @@
   locTolRefPeak = "highest",
   gateCombn = "min",
   calcCytPosGates = FALSE,
-  calcSinglePosGates = FALSE,
   includeLocCondition = TRUE,
   pathFbeta = NULL,
   fbetaPatchPy2Compat = TRUE,
@@ -981,7 +978,6 @@
       gateCombn = gateCombn,
       tolClust = tolClust,
       calcCytPosGates = calcCytPosGates,
-      calcSinglePosGates = calcSinglePosGates,
       includeLocCondition = includeLocCondition
     )
 

--- a/tests/testthat/test-analysis-helpers.R
+++ b/tests/testthat/test-analysis-helpers.R
@@ -1,0 +1,41 @@
+test_that("analysis helpers do not expose or forward calcSinglePosGates", {
+  skip_if_not_installed("stimgate")
+
+  root_dir <- testthat::test_path("../..")
+  script_misc <- file.path(root_dir, "scripts", "r", "sim-misc.R")
+  script_bw <- file.path(root_dir, "scripts", "r", "sim-bandwidth.R")
+  script_comp <- file.path(root_dir, "scripts", "r", "sim-compare-freq_bs.R")
+
+  skip_if_not(file.exists(script_bw), "sim-bandwidth.R not found")
+
+  source(script_misc, local = TRUE)
+  source(script_bw, local = TRUE)
+  source(script_comp, local = TRUE)
+
+  expect_false("calcSinglePosGates" %in% names(formals(.simBandwidthBsFreq)))
+  expect_false("calcSinglePosGates" %in% names(formals(.simCompareStimgateRows)))
+  expect_false("calcSinglePosGates" %in% names(formals(.simCompareFreqBs)))
+
+  # Test that .simBandwidthBsFreq calls gateStim without unused-argument error
+  res <- .simBandwidthBsFreq(
+    nSample = 1L,
+    nMarker = 1L,
+    nCondition = 2L,
+    nCluster = 2L,
+    nIter = 1L,
+    biasUns = 0,
+    bwMtd = "hpi1",
+    nCellStim = 50L,
+    probResponse = 0.1,
+    meanPos = 5,
+    transformation = "gaussian",
+    samplePerturbationSd = 0,
+    conditionPerturbationSd = 0,
+    clusterPerturbationSd = 0,
+    backgroundRelativeToResponse = 0.1,
+    ncellUnsRelativeToStim = 1
+  )
+
+  expect_s3_class(res, "data.frame")
+  expect_true(nrow(res) > 0)
+})


### PR DESCRIPTION
Remove obsolete calcSinglePosGates parameter signatures and forwarding calls to gateStim() from scripts/r/sim-bandwidth.R, scripts/r/sim-compare-freq_bs.R, and scripts/r/sim-bw-adaptive.R following the removal of single-positive gating support. Add regression test in tests/testthat/test-analysis-helpers.R.

---
*PR created automatically by Jules for task [14687329457589363077](https://jules.google.com/task/14687329457589363077) started by @MiguelRodo*