### PR TITLE
Fix readRDS warnings for missing bandwidth files in plotStim

### DIFF
--- a/R/plot_gate.R
+++ b/R/plot_gate.R
@@ -528,7 +528,11 @@ plotStim <- function(
   } else {
     ""
   }
-  bw <- tryCatch(readRDS(pathBwProject), error = function(e) "nrd0")
+  bw <- if (nzchar(pathBwProject) && file.exists(pathBwProject)) {
+    tryCatch(readRDS(pathBwProject), error = function(e) "nrd0")
+  } else {
+    "nrd0"
+  }
   plotTbl <- .plotGateUvMarkerGetPlotTbl(
     marker = marker,
     chnl = chnl,


### PR DESCRIPTION
Fixed warnings in plotStim/plot_gate.R when reading missing intermediate RDS files by checking file existence prior to calling readRDS.

---
*PR created automatically by Jules for task [17827822222931814451](https://jules.google.com/task/17827822222931814451) started by @MiguelRodo*