### PR TITLE
Fix analysis calls and helper dependency ordering in analysis QMDs

### DIFF
--- a/analysis/1-sim-trans.qmd
+++ b/analysis/1-sim-trans.qmd
@@ -48,6 +48,8 @@ if (
   }
 }
 scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# sim-misc.R must be sourced before sim-trans.R for helper utilities.
 for (fn in c("sim-misc.R", "sim-trans.R")) {
   source(file.path(scripts_r_dir, fn))
 }

--- a/analysis/2-sim-bw-freq_bs-global.qmd
+++ b/analysis/2-sim-bw-freq_bs-global.qmd
@@ -120,6 +120,8 @@ if (
   }
 }
 scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# sim-misc.R must be sourced before sim-bandwidth.R for simulation utilities.
 for (fn in c("sim-misc.R", "sim-bandwidth.R")) {
   source(file.path(scripts_r_dir, fn))
 }
@@ -544,7 +546,7 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
 
         out <- tryCatch(
           {
-            sim_res <- stimgate:::.simBandwidthBsFreq(
+            sim_res <- .simBandwidthBsFreq(
               nSample = 5,
               nMarker = 1,
               nCondition = 2,
@@ -961,7 +963,7 @@ row_seed <- furrr:::make_seeds(
 
 assign(".Random.seed", row_seed, envir = .GlobalEnv)
 
-# debugonce(stimgate:::.simBandwidthBsFreq)
+# debugonce(.simBandwidthBsFreq)
 # undebug(.getCpUnsLocGetProb)
 # undebug(.getCpUnsLocGetCp)
 debug(.getCpUnsLocCondition)

--- a/analysis/3-sim-bw-est-base.qmd
+++ b/analysis/3-sim-bw-est-base.qmd
@@ -30,6 +30,8 @@ if (
   }
 }
 scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# sim-misc.R must be sourced before sim-bandwidth.R for simulation utilities.
 for (fn in c("sim-misc.R", "sim-bandwidth.R")) {
   source(file.path(scripts_r_dir, fn))
 }
@@ -159,7 +161,7 @@ for (i in seq_len(nrow(sim_grid))) {
   )
 
   message("Running: ", settings_row)
-  bw_list_raw_mtd_loop[[i]] <- stimgate:::.simBandwidthEstBwDirect(
+  bw_list_raw_mtd_loop[[i]] <- .simBandwidthEstBwDirect(
     nSample = 10,
     nMarker = 1,
     nCondition = 2,
@@ -365,7 +367,7 @@ bw_list_raw_mtd <- progressr::with_progress({
 
       out <- tryCatch(
         {
-          sim_res <- stimgate:::.simBandwidthEstBwDirect(
+          sim_res <- .simBandwidthEstBwDirect(
             nSample = 50,
             nMarker = 1,
             nCondition = 2,

--- a/analysis/4-sim-bw-est-norm.qmd
+++ b/analysis/4-sim-bw-est-norm.qmd
@@ -30,6 +30,8 @@ if (
   }
 }
 scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# sim-misc.R must be sourced before sim-bandwidth.R for simulation utilities.
 for (fn in c("sim-misc.R", "sim-bandwidth.R")) {
   source(file.path(scripts_r_dir, fn))
 }
@@ -385,7 +387,7 @@ bw_list_raw_mtd <- progressr::with_progress({
 
       out <- tryCatch(
         {
-          sim_res <- stimgate:::.simBandwidthEstBwDirect(
+          sim_res <- .simBandwidthEstBwDirect(
             nSample = 10,
             nMarker = 1,
             nCondition = 2,

--- a/analysis/5-sim-bw-est-adaptive.qmd
+++ b/analysis/5-sim-bw-est-adaptive.qmd
@@ -120,6 +120,8 @@ if (
   }
 }
 scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# sim-misc.R must be sourced before sim-bandwidth.R for simulation utilities.
 for (fn in c("sim-misc.R", "sim-bandwidth.R")) {
   source(file.path(scripts_r_dir, fn))
 }
@@ -561,7 +563,7 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
 
         out <- tryCatch(
           {
-            sim_res <- stimgate:::.simBandwidthEstBwDirectAdaptive(
+            sim_res <- .simBandwidthEstBwDirectAdaptive(
               nSample = if (.isDev()) 1L else 5L,
               nMarker = 1L,
               nCondition = 2L,

--- a/analysis/6-sim-bw-freq_bs-adaptive.qmd
+++ b/analysis/6-sim-bw-freq_bs-adaptive.qmd
@@ -120,6 +120,8 @@ if (
   }
 }
 scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# sim-misc.R must be sourced before sim-bandwidth.R for simulation utilities.
 for (fn in c("sim-misc.R", "sim-bandwidth.R")) {
   source(file.path(scripts_r_dir, fn))
 }
@@ -319,7 +321,7 @@ A helper for running the adaptive version. This deliberately checks that the loa
 ```{r}
 #| label: run-helper
 .run_sim_bandwidth_bs_freq_adaptive <- function(...) {
-  fn <- stimgate:::.simBandwidthBsFreq
+  fn <- .simBandwidthBsFreq
   arg <- list(...)
   formal_nm <- names(formals(fn))
   required_nm <- c("bwAdaptiveCore", "bwAdaptiveExtra")

--- a/analysis/7-sim-compare-freq_bs.qmd
+++ b/analysis/7-sim-compare-freq_bs.qmd
@@ -34,10 +34,14 @@ if (!requireNamespace("cytoUtils", quietly = TRUE)) {
   warning("Package 'cytoUtils' is not installed. Tailgate comparisons will fail if run.")
 }
 
-path_compare_helpers <- file.path(
-  root_dir, "scripts", "r", "sim-compare-freq_bs.R"
-)
-source(path_compare_helpers)
+scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# 1. sim-misc.R: general simulation utilities and transformation lookups
+# 2. sim-bandwidth.R: location details reader and bandwidth helpers
+# 3. sim-compare-freq_bs.R: comparison functions requiring sim-bandwidth.R helpers
+for (fn in c("sim-misc.R", "sim-bandwidth.R", "sim-compare-freq_bs.R")) {
+  source(file.path(scripts_r_dir, fn))
+}
 ```
 
 ### Aim
@@ -163,7 +167,7 @@ compare_list_raw_loop <- vector("list", nrow(sim_grid))
 for (i in seq_len(nrow(sim_grid))) {
   message(paste0("Running simulation ", i, " of ", nrow(sim_grid)))
 
-  compare_list_raw_loop[[i]] <- stimgate:::.simCompareFreqBs(
+  compare_list_raw_loop[[i]] <- .simCompareFreqBs(
     nSample = 5,
     nMarker = 1,
     nCondition = 2,
@@ -296,7 +300,7 @@ compare_list_raw <- progressr::with_progress({
 
       out <- tryCatch(
         {
-          sim_res <- stimgate:::.simCompareFreqBs(
+          sim_res <- .simCompareFreqBs(
             nSample = 5,
             nMarker = 1,
             nCondition = 2,
@@ -477,7 +481,7 @@ compare_tbl_focus <- compare_tbl |>
     sq_freq_error = freq_error^2
   )
 
-compare_summary <- stimgate:::.simCompareSummariseFreqBs(compare_tbl)
+compare_summary <- .simCompareSummariseFreqBs(compare_tbl)
 
 compare_summary |>
   dplyr::arrange(rmse) |>

--- a/analysis/split/2-sim-bw-freq_bs-global-1.qmd
+++ b/analysis/split/2-sim-bw-freq_bs-global-1.qmd
@@ -120,6 +120,8 @@ if (
   }
 }
 scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# sim-misc.R must be sourced before sim-bandwidth.R for simulation utilities.
 for (fn in c("sim-misc.R", "sim-bandwidth.R")) {
   source(file.path(scripts_r_dir, fn))
 }
@@ -549,7 +551,7 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
 
         out <- tryCatch(
           {
-            sim_res <- stimgate:::.simBandwidthBsFreq(
+            sim_res <- .simBandwidthBsFreq(
               nSample = 5,
               nMarker = 1,
               nCondition = 2,

--- a/analysis/split/2-sim-bw-freq_bs-global-2.qmd
+++ b/analysis/split/2-sim-bw-freq_bs-global-2.qmd
@@ -120,6 +120,8 @@ if (
   }
 }
 scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# sim-misc.R must be sourced before sim-bandwidth.R for simulation utilities.
 for (fn in c("sim-misc.R", "sim-bandwidth.R")) {
   source(file.path(scripts_r_dir, fn))
 }
@@ -549,7 +551,7 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
 
         out <- tryCatch(
           {
-            sim_res <- stimgate:::.simBandwidthBsFreq(
+            sim_res <- .simBandwidthBsFreq(
               nSample = 5,
               nMarker = 1,
               nCondition = 2,

--- a/analysis/split/2-sim-bw-freq_bs-global-3.qmd
+++ b/analysis/split/2-sim-bw-freq_bs-global-3.qmd
@@ -120,6 +120,8 @@ if (
   }
 }
 scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# sim-misc.R must be sourced before sim-bandwidth.R for simulation utilities.
 for (fn in c("sim-misc.R", "sim-bandwidth.R")) {
   source(file.path(scripts_r_dir, fn))
 }
@@ -549,7 +551,7 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
 
         out <- tryCatch(
           {
-            sim_res <- stimgate:::.simBandwidthBsFreq(
+            sim_res <- .simBandwidthBsFreq(
               nSample = 5,
               nMarker = 1,
               nCondition = 2,

--- a/analysis/split/2-sim-bw-freq_bs-global-4.qmd
+++ b/analysis/split/2-sim-bw-freq_bs-global-4.qmd
@@ -120,6 +120,8 @@ if (
   }
 }
 scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# sim-misc.R must be sourced before sim-bandwidth.R for simulation utilities.
 for (fn in c("sim-misc.R", "sim-bandwidth.R")) {
   source(file.path(scripts_r_dir, fn))
 }
@@ -549,7 +551,7 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
 
         out <- tryCatch(
           {
-            sim_res <- stimgate:::.simBandwidthBsFreq(
+            sim_res <- .simBandwidthBsFreq(
               nSample = 5,
               nMarker = 1,
               nCondition = 2,

--- a/analysis/split/6-sim-bw-freq_bs-adaptive-1.qmd
+++ b/analysis/split/6-sim-bw-freq_bs-adaptive-1.qmd
@@ -120,6 +120,8 @@ if (
   }
 }
 scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# sim-misc.R must be sourced before sim-bandwidth.R for simulation utilities.
 for (fn in c("sim-misc.R", "sim-bandwidth.R")) {
   source(file.path(scripts_r_dir, fn))
 }
@@ -319,7 +321,7 @@ A helper for running the adaptive version. This deliberately checks that the loa
 ```{r}
 #| label: run-helper
 .run_sim_bandwidth_bs_freq_adaptive <- function(...) {
-  fn <- stimgate:::.simBandwidthBsFreq
+  fn <- .simBandwidthBsFreq
   arg <- list(...)
   formal_nm <- names(formals(fn))
   required_nm <- c("bwAdaptiveCore", "bwAdaptiveExtra")

--- a/analysis/split/6-sim-bw-freq_bs-adaptive-2.qmd
+++ b/analysis/split/6-sim-bw-freq_bs-adaptive-2.qmd
@@ -120,6 +120,8 @@ if (
   }
 }
 scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# sim-misc.R must be sourced before sim-bandwidth.R for simulation utilities.
 for (fn in c("sim-misc.R", "sim-bandwidth.R")) {
   source(file.path(scripts_r_dir, fn))
 }
@@ -319,7 +321,7 @@ A helper for running the adaptive version. This deliberately checks that the loa
 ```{r}
 #| label: run-helper
 .run_sim_bandwidth_bs_freq_adaptive <- function(...) {
-  fn <- stimgate:::.simBandwidthBsFreq
+  fn <- .simBandwidthBsFreq
   arg <- list(...)
   formal_nm <- names(formals(fn))
   required_nm <- c("bwAdaptiveCore", "bwAdaptiveExtra")

--- a/analysis/split/6-sim-bw-freq_bs-adaptive-3.qmd
+++ b/analysis/split/6-sim-bw-freq_bs-adaptive-3.qmd
@@ -120,6 +120,8 @@ if (
   }
 }
 scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# sim-misc.R must be sourced before sim-bandwidth.R for simulation utilities.
 for (fn in c("sim-misc.R", "sim-bandwidth.R")) {
   source(file.path(scripts_r_dir, fn))
 }
@@ -319,7 +321,7 @@ A helper for running the adaptive version. This deliberately checks that the loa
 ```{r}
 #| label: run-helper
 .run_sim_bandwidth_bs_freq_adaptive <- function(...) {
-  fn <- stimgate:::.simBandwidthBsFreq
+  fn <- .simBandwidthBsFreq
   arg <- list(...)
   formal_nm <- names(formals(fn))
   required_nm <- c("bwAdaptiveCore", "bwAdaptiveExtra")

--- a/analysis/split/6-sim-bw-freq_bs-adaptive-4.qmd
+++ b/analysis/split/6-sim-bw-freq_bs-adaptive-4.qmd
@@ -120,6 +120,8 @@ if (
   }
 }
 scripts_r_dir <- file.path(root_dir, "scripts", "r")
+# Source simulation helpers in dependency order:
+# sim-misc.R must be sourced before sim-bandwidth.R for simulation utilities.
 for (fn in c("sim-misc.R", "sim-bandwidth.R")) {
   source(file.path(scripts_r_dir, fn))
 }
@@ -319,7 +321,7 @@ A helper for running the adaptive version. This deliberately checks that the loa
 ```{r}
 #| label: run-helper
 .run_sim_bandwidth_bs_freq_adaptive <- function(...) {
-  fn <- stimgate:::.simBandwidthBsFreq
+  fn <- .simBandwidthBsFreq
   arg <- list(...)
   formal_nm <- names(formals(fn))
   required_nm <- c("bwAdaptiveCore", "bwAdaptiveExtra")


### PR DESCRIPTION
Resolves issues #226 and #228:
1. Replaced stale `stimgate:::.sim...` calls across analysis QMDs and split variants with direct calls to local helper functions sourced from `scripts/r/`.
2. Updated QMD setup blocks (especially `analysis/7-sim-compare-freq_bs.qmd`) to source simulation helpers in deterministic dependency order (`sim-misc.R` -> `sim-bandwidth.R` -> `sim-compare-freq_bs.R`) with explanatory comments.

---
*PR created automatically by Jules for task [11447674030634967193](https://jules.google.com/task/11447674030634967193) started by @MiguelRodo*