### PR TITLE
Audit simulation wrapper parameters against gateStim API (#229)

### DIFF
--- a/analysis/2-sim-bw-freq_bs-global.qmd
+++ b/analysis/2-sim-bw-freq_bs-global.qmd
@@ -188,6 +188,14 @@ bandwidth_value_vec <- c(
   0.2, 0.25, 0.5, 0.75, 1, 1.25, 1.5
   )
 
+# StimGate method settings for bandwidth-performance analysis:
+# Cluster refinement (tolClust) is intentionally set to NULL (OFF) to isolate and
+# measure the effect of the bandwidth selector itself without multi-sample
+# cluster adjustments modifying thresholds post-local-FDR.
+tol_clust <- NULL
+loc_enforce_shape_threshold <- FALSE
+calc_cyt_pos_gates <- FALSE
+
 # can vary these later
 bandwidth_ncell_upper_vec <- c(2.5e3, 5e3, 1e4, 2e4, 5e4, 1e5, 2e5, 5e5, Inf)
 bandwidth_ncell_lower_vec <- c(0, 10, 20, 30, 50, 100, 200, 500, 1e3)
@@ -350,7 +358,9 @@ for (i in seq_len(nrow(sim_grid_loop))[1]) {
       sim_grid_loop$n_cell_uns_relative_to_stim[i],
     covEvMin = 1.5,
     covEvMax = 1.5,
-    tolClust = NULL
+    tolClust = tol_clust,
+    locEnforceShapeThreshold = loc_enforce_shape_threshold,
+    calcCytPosGates = calc_cyt_pos_gates
   ) |>
     dplyr::mutate(
       transformation = sim_grid_loop$transformation[i],
@@ -569,7 +579,9 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
               ncellUnsRelativeToStim = n_cell_uns_relative_to_stim,
               covEvMin = 1.5,
               covEvMax = 1.5,
-              tolClust = NULL
+              tolClust = tol_clust,
+              locEnforceShapeThreshold = loc_enforce_shape_threshold,
+              calcCytPosGates = calc_cyt_pos_gates
             ) |>
               dplyr::mutate(
                 transformation = transformation,
@@ -992,7 +1004,9 @@ sim_res <- .simBandwidthBsFreq(
   ncellUnsRelativeToStim = row[["n_cell_uns_relative_to_stim"]],
   covEvMin = 1.5,
   covEvMax = 1.5,
-  tolClust = NULL
+  tolClust = tol_clust,
+  locEnforceShapeThreshold = loc_enforce_shape_threshold,
+  calcCytPosGates = calc_cyt_pos_gates
 )
 
 # NEXT

--- a/analysis/6-sim-bw-freq_bs-adaptive.qmd
+++ b/analysis/6-sim-bw-freq_bs-adaptive.qmd
@@ -181,6 +181,14 @@ bw_extra_vec <- bandwidth_value_vec
 bw_crossover_vec <- c(NA_real_, 4.5, 5.5, 6.5)[[1]]
 bw_transition_width_vec <- c(0, 0.25)[[1]]
 
+# StimGate method settings for bandwidth-performance analysis:
+# Cluster refinement (tolClust) is intentionally set to NULL (OFF) to isolate and
+# measure the effect of the bandwidth selector itself without multi-sample
+# cluster adjustments modifying thresholds post-local-FDR.
+tol_clust <- NULL
+loc_enforce_shape_threshold <- FALSE
+calc_cyt_pos_gates <- FALSE
+
 # Can vary these later.
 bandwidth_ncell_upper_vec <- c(2.5e3, 5e3, 1e4, 2e4, 5e4, 1e5, 2e5, 5e5, Inf)
 bandwidth_ncell_lower_vec <- c(0, 10, 20, 30, 50, 100, 200, 500, 1e3)
@@ -389,7 +397,9 @@ for (i in seq_len(nrow(sim_grid))) {
       sim_grid$n_cell_uns_relative_to_stim[i],
     covEvMin = 1.5,
     covEvMax = 1.5,
-    tolClust = NULL
+    tolClust = tol_clust,
+    locEnforceShapeThreshold = loc_enforce_shape_threshold,
+    calcCytPosGates = calc_cyt_pos_gates
   ) |>
     dplyr::mutate(
       transformation = sim_grid$transformation[i],
@@ -633,7 +643,9 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
               ncellUnsRelativeToStim = n_cell_uns_relative_to_stim,
               covEvMin = 1.5,
               covEvMax = 1.5,
-              tolClust = NULL
+              tolClust = tol_clust,
+              locEnforceShapeThreshold = loc_enforce_shape_threshold,
+              calcCytPosGates = calc_cyt_pos_gates
             ) |>
               dplyr::mutate(
                 transformation = transformation,

--- a/analysis/7-sim-compare-freq_bs.qmd
+++ b/analysis/7-sim-compare-freq_bs.qmd
@@ -95,6 +95,15 @@ n_cell_uns_relative_to_stim_vec <- c(0.1, 0.2, 0.5, 1, 2, 5, 10)[4]
 bw_fixed <- 0.5
 bias_uns_vec <- c(0, 0.05, 0.1, seq(0.2, 2, by = 0.2))[c(2, 4)]
 
+# StimGate method settings for full method comparison (StimGate vs alternatives):
+# Cluster refinement is enabled (tolClust = 1e-7) matching current gateStim() defaults
+# to represent the full one-marker StimGate procedure.
+# locEnforceShapeThreshold is explicitly FALSE for primary comparison.
+# calcCytPosGates is explicitly FALSE for one-marker simulations.
+tol_clust <- 1e-7
+loc_enforce_shape_threshold <- FALSE
+calc_cyt_pos_gates <- FALSE
+
 fbeta_beta <- 0.8
 fbeta_theta <- 2
 fbeta_width <- 10
@@ -190,7 +199,9 @@ for (i in seq_len(nrow(sim_grid))) {
     ncellUnsRelativeToStim = sim_grid$n_cell_uns_relative_to_stim[i],
     covEvMin = 1.5,
     covEvMax = 1.5,
-    tolClust = NULL,
+    tolClust = tol_clust,
+    locEnforceShapeThreshold = loc_enforce_shape_threshold,
+    calcCytPosGates = calc_cyt_pos_gates,
     includeLocCondition = TRUE,
     pathFbeta = path_fbeta,
     fbetaBeta = fbeta_beta,
@@ -323,7 +334,9 @@ compare_list_raw <- progressr::with_progress({
             ncellUnsRelativeToStim = n_cell_uns_relative_to_stim,
             covEvMin = 1.5,
             covEvMax = 1.5,
-            tolClust = NULL,
+            tolClust = tol_clust,
+            locEnforceShapeThreshold = loc_enforce_shape_threshold,
+            calcCytPosGates = calc_cyt_pos_gates,
             includeLocCondition = TRUE,
             pathFbeta = path_fbeta,
             fbetaBeta = fbeta_beta,

--- a/analysis/split/2-sim-bw-freq_bs-global-1.qmd
+++ b/analysis/split/2-sim-bw-freq_bs-global-1.qmd
@@ -188,6 +188,14 @@ bandwidth_value_vec <- c(
   0.2, 0.25, 0.5, 0.75, 1, 1.25, 1.5
   )
 
+# StimGate method settings for bandwidth-performance analysis:
+# Cluster refinement (tolClust) is intentionally set to NULL (OFF) to isolate and
+# measure the effect of the bandwidth selector itself without multi-sample
+# cluster adjustments modifying thresholds post-local-FDR.
+tol_clust <- NULL
+loc_enforce_shape_threshold <- FALSE
+calc_cyt_pos_gates <- FALSE
+
 # can vary these later
 bandwidth_ncell_upper_vec <- c(2.5e3, 5e3, 1e4, 2e4, 5e4, 1e5, 2e5, 5e5, Inf)
 bandwidth_ncell_lower_vec <- c(0, 10, 20, 30, 50, 100, 200, 500, 1e3)
@@ -346,7 +354,9 @@ for (i in seq_len(nrow(sim_grid))) {
       sim_grid$n_cell_uns_relative_to_stim[i],
     covEvMin = 1.5,
     covEvMax = 1.5,
-    tolClust = NULL
+    tolClust = tol_clust,
+    locEnforceShapeThreshold = loc_enforce_shape_threshold,
+    calcCytPosGates = calc_cyt_pos_gates
   ) |>
     dplyr::mutate(
       transformation = sim_grid$transformation[i],
@@ -574,7 +584,9 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
               ncellUnsRelativeToStim = n_cell_uns_relative_to_stim,
               covEvMin = 1.5,
               covEvMax = 1.5,
-              tolClust = NULL
+              tolClust = tol_clust,
+              locEnforceShapeThreshold = loc_enforce_shape_threshold,
+              calcCytPosGates = calc_cyt_pos_gates
             ) |>
               dplyr::mutate(
                 transformation = transformation,

--- a/analysis/split/2-sim-bw-freq_bs-global-2.qmd
+++ b/analysis/split/2-sim-bw-freq_bs-global-2.qmd
@@ -188,6 +188,14 @@ bandwidth_value_vec <- c(
   0.2, 0.25, 0.5, 0.75, 1, 1.25, 1.5
   )
 
+# StimGate method settings for bandwidth-performance analysis:
+# Cluster refinement (tolClust) is intentionally set to NULL (OFF) to isolate and
+# measure the effect of the bandwidth selector itself without multi-sample
+# cluster adjustments modifying thresholds post-local-FDR.
+tol_clust <- NULL
+loc_enforce_shape_threshold <- FALSE
+calc_cyt_pos_gates <- FALSE
+
 # can vary these later
 bandwidth_ncell_upper_vec <- c(2.5e3, 5e3, 1e4, 2e4, 5e4, 1e5, 2e5, 5e5, Inf)
 bandwidth_ncell_lower_vec <- c(0, 10, 20, 30, 50, 100, 200, 500, 1e3)
@@ -346,7 +354,9 @@ for (i in seq_len(nrow(sim_grid))) {
       sim_grid$n_cell_uns_relative_to_stim[i],
     covEvMin = 1.5,
     covEvMax = 1.5,
-    tolClust = NULL
+    tolClust = tol_clust,
+    locEnforceShapeThreshold = loc_enforce_shape_threshold,
+    calcCytPosGates = calc_cyt_pos_gates
   ) |>
     dplyr::mutate(
       transformation = sim_grid$transformation[i],
@@ -574,7 +584,9 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
               ncellUnsRelativeToStim = n_cell_uns_relative_to_stim,
               covEvMin = 1.5,
               covEvMax = 1.5,
-              tolClust = NULL
+              tolClust = tol_clust,
+              locEnforceShapeThreshold = loc_enforce_shape_threshold,
+              calcCytPosGates = calc_cyt_pos_gates
             ) |>
               dplyr::mutate(
                 transformation = transformation,

--- a/analysis/split/2-sim-bw-freq_bs-global-3.qmd
+++ b/analysis/split/2-sim-bw-freq_bs-global-3.qmd
@@ -188,6 +188,14 @@ bandwidth_value_vec <- c(
   0.2, 0.25, 0.5, 0.75, 1, 1.25, 1.5
   )
 
+# StimGate method settings for bandwidth-performance analysis:
+# Cluster refinement (tolClust) is intentionally set to NULL (OFF) to isolate and
+# measure the effect of the bandwidth selector itself without multi-sample
+# cluster adjustments modifying thresholds post-local-FDR.
+tol_clust <- NULL
+loc_enforce_shape_threshold <- FALSE
+calc_cyt_pos_gates <- FALSE
+
 # can vary these later
 bandwidth_ncell_upper_vec <- c(2.5e3, 5e3, 1e4, 2e4, 5e4, 1e5, 2e5, 5e5, Inf)
 bandwidth_ncell_lower_vec <- c(0, 10, 20, 30, 50, 100, 200, 500, 1e3)
@@ -346,7 +354,9 @@ for (i in seq_len(nrow(sim_grid))) {
       sim_grid$n_cell_uns_relative_to_stim[i],
     covEvMin = 1.5,
     covEvMax = 1.5,
-    tolClust = NULL
+    tolClust = tol_clust,
+    locEnforceShapeThreshold = loc_enforce_shape_threshold,
+    calcCytPosGates = calc_cyt_pos_gates
   ) |>
     dplyr::mutate(
       transformation = sim_grid$transformation[i],
@@ -574,7 +584,9 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
               ncellUnsRelativeToStim = n_cell_uns_relative_to_stim,
               covEvMin = 1.5,
               covEvMax = 1.5,
-              tolClust = NULL
+              tolClust = tol_clust,
+              locEnforceShapeThreshold = loc_enforce_shape_threshold,
+              calcCytPosGates = calc_cyt_pos_gates
             ) |>
               dplyr::mutate(
                 transformation = transformation,

--- a/analysis/split/2-sim-bw-freq_bs-global-4.qmd
+++ b/analysis/split/2-sim-bw-freq_bs-global-4.qmd
@@ -188,6 +188,14 @@ bandwidth_value_vec <- c(
   0.2, 0.25, 0.5, 0.75, 1, 1.25, 1.5
   )
 
+# StimGate method settings for bandwidth-performance analysis:
+# Cluster refinement (tolClust) is intentionally set to NULL (OFF) to isolate and
+# measure the effect of the bandwidth selector itself without multi-sample
+# cluster adjustments modifying thresholds post-local-FDR.
+tol_clust <- NULL
+loc_enforce_shape_threshold <- FALSE
+calc_cyt_pos_gates <- FALSE
+
 # can vary these later
 bandwidth_ncell_upper_vec <- c(2.5e3, 5e3, 1e4, 2e4, 5e4, 1e5, 2e5, 5e5, Inf)
 bandwidth_ncell_lower_vec <- c(0, 10, 20, 30, 50, 100, 200, 500, 1e3)
@@ -346,7 +354,9 @@ for (i in seq_len(nrow(sim_grid))) {
       sim_grid$n_cell_uns_relative_to_stim[i],
     covEvMin = 1.5,
     covEvMax = 1.5,
-    tolClust = NULL
+    tolClust = tol_clust,
+    locEnforceShapeThreshold = loc_enforce_shape_threshold,
+    calcCytPosGates = calc_cyt_pos_gates
   ) |>
     dplyr::mutate(
       transformation = sim_grid$transformation[i],
@@ -574,7 +584,9 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
               ncellUnsRelativeToStim = n_cell_uns_relative_to_stim,
               covEvMin = 1.5,
               covEvMax = 1.5,
-              tolClust = NULL
+              tolClust = tol_clust,
+              locEnforceShapeThreshold = loc_enforce_shape_threshold,
+              calcCytPosGates = calc_cyt_pos_gates
             ) |>
               dplyr::mutate(
                 transformation = transformation,

--- a/analysis/split/6-sim-bw-freq_bs-adaptive-1.qmd
+++ b/analysis/split/6-sim-bw-freq_bs-adaptive-1.qmd
@@ -181,6 +181,14 @@ bw_extra_vec <- bandwidth_value_vec
 bw_crossover_vec <- c(NA_real_, 4.5, 5.5, 6.5)[[1]]
 bw_transition_width_vec <- c(0, 0.25)[[1]]
 
+# StimGate method settings for bandwidth-performance analysis:
+# Cluster refinement (tolClust) is intentionally set to NULL (OFF) to isolate and
+# measure the effect of the bandwidth selector itself without multi-sample
+# cluster adjustments modifying thresholds post-local-FDR.
+tol_clust <- NULL
+loc_enforce_shape_threshold <- FALSE
+calc_cyt_pos_gates <- FALSE
+
 # Can vary these later.
 bandwidth_ncell_upper_vec <- c(2.5e3, 5e3, 1e4, 2e4, 5e4, 1e5, 2e5, 5e5, Inf)
 bandwidth_ncell_lower_vec <- c(0, 10, 20, 30, 50, 100, 200, 500, 1e3)
@@ -389,7 +397,9 @@ for (i in seq_len(nrow(sim_grid))) {
       sim_grid$n_cell_uns_relative_to_stim[i],
     covEvMin = 1.5,
     covEvMax = 1.5,
-    tolClust = NULL
+    tolClust = tol_clust,
+    locEnforceShapeThreshold = loc_enforce_shape_threshold,
+    calcCytPosGates = calc_cyt_pos_gates
   ) |>
     dplyr::mutate(
       transformation = sim_grid$transformation[i],
@@ -633,7 +643,9 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
               ncellUnsRelativeToStim = n_cell_uns_relative_to_stim,
               covEvMin = 1.5,
               covEvMax = 1.5,
-              tolClust = NULL
+              tolClust = tol_clust,
+              locEnforceShapeThreshold = loc_enforce_shape_threshold,
+              calcCytPosGates = calc_cyt_pos_gates
             ) |>
               dplyr::mutate(
                 transformation = transformation,

--- a/analysis/split/6-sim-bw-freq_bs-adaptive-2.qmd
+++ b/analysis/split/6-sim-bw-freq_bs-adaptive-2.qmd
@@ -181,6 +181,14 @@ bw_extra_vec <- bandwidth_value_vec
 bw_crossover_vec <- c(NA_real_, 4.5, 5.5, 6.5)[[1]]
 bw_transition_width_vec <- c(0, 0.25)[[1]]
 
+# StimGate method settings for bandwidth-performance analysis:
+# Cluster refinement (tolClust) is intentionally set to NULL (OFF) to isolate and
+# measure the effect of the bandwidth selector itself without multi-sample
+# cluster adjustments modifying thresholds post-local-FDR.
+tol_clust <- NULL
+loc_enforce_shape_threshold <- FALSE
+calc_cyt_pos_gates <- FALSE
+
 # Can vary these later.
 bandwidth_ncell_upper_vec <- c(2.5e3, 5e3, 1e4, 2e4, 5e4, 1e5, 2e5, 5e5, Inf)
 bandwidth_ncell_lower_vec <- c(0, 10, 20, 30, 50, 100, 200, 500, 1e3)
@@ -389,7 +397,9 @@ for (i in seq_len(nrow(sim_grid))) {
       sim_grid$n_cell_uns_relative_to_stim[i],
     covEvMin = 1.5,
     covEvMax = 1.5,
-    tolClust = NULL
+    tolClust = tol_clust,
+    locEnforceShapeThreshold = loc_enforce_shape_threshold,
+    calcCytPosGates = calc_cyt_pos_gates
   ) |>
     dplyr::mutate(
       transformation = sim_grid$transformation[i],
@@ -633,7 +643,9 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
               ncellUnsRelativeToStim = n_cell_uns_relative_to_stim,
               covEvMin = 1.5,
               covEvMax = 1.5,
-              tolClust = NULL
+              tolClust = tol_clust,
+              locEnforceShapeThreshold = loc_enforce_shape_threshold,
+              calcCytPosGates = calc_cyt_pos_gates
             ) |>
               dplyr::mutate(
                 transformation = transformation,

--- a/analysis/split/6-sim-bw-freq_bs-adaptive-3.qmd
+++ b/analysis/split/6-sim-bw-freq_bs-adaptive-3.qmd
@@ -181,6 +181,14 @@ bw_extra_vec <- bandwidth_value_vec
 bw_crossover_vec <- c(NA_real_, 4.5, 5.5, 6.5)[[1]]
 bw_transition_width_vec <- c(0, 0.25)[[1]]
 
+# StimGate method settings for bandwidth-performance analysis:
+# Cluster refinement (tolClust) is intentionally set to NULL (OFF) to isolate and
+# measure the effect of the bandwidth selector itself without multi-sample
+# cluster adjustments modifying thresholds post-local-FDR.
+tol_clust <- NULL
+loc_enforce_shape_threshold <- FALSE
+calc_cyt_pos_gates <- FALSE
+
 # Can vary these later.
 bandwidth_ncell_upper_vec <- c(2.5e3, 5e3, 1e4, 2e4, 5e4, 1e5, 2e5, 5e5, Inf)
 bandwidth_ncell_lower_vec <- c(0, 10, 20, 30, 50, 100, 200, 500, 1e3)
@@ -389,7 +397,9 @@ for (i in seq_len(nrow(sim_grid))) {
       sim_grid$n_cell_uns_relative_to_stim[i],
     covEvMin = 1.5,
     covEvMax = 1.5,
-    tolClust = NULL
+    tolClust = tol_clust,
+    locEnforceShapeThreshold = loc_enforce_shape_threshold,
+    calcCytPosGates = calc_cyt_pos_gates
   ) |>
     dplyr::mutate(
       transformation = sim_grid$transformation[i],
@@ -633,7 +643,9 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
               ncellUnsRelativeToStim = n_cell_uns_relative_to_stim,
               covEvMin = 1.5,
               covEvMax = 1.5,
-              tolClust = NULL
+              tolClust = tol_clust,
+              locEnforceShapeThreshold = loc_enforce_shape_threshold,
+              calcCytPosGates = calc_cyt_pos_gates
             ) |>
               dplyr::mutate(
                 transformation = transformation,

--- a/analysis/split/6-sim-bw-freq_bs-adaptive-4.qmd
+++ b/analysis/split/6-sim-bw-freq_bs-adaptive-4.qmd
@@ -181,6 +181,14 @@ bw_extra_vec <- bandwidth_value_vec
 bw_crossover_vec <- c(NA_real_, 4.5, 5.5, 6.5)[[1]]
 bw_transition_width_vec <- c(0, 0.25)[[1]]
 
+# StimGate method settings for bandwidth-performance analysis:
+# Cluster refinement (tolClust) is intentionally set to NULL (OFF) to isolate and
+# measure the effect of the bandwidth selector itself without multi-sample
+# cluster adjustments modifying thresholds post-local-FDR.
+tol_clust <- NULL
+loc_enforce_shape_threshold <- FALSE
+calc_cyt_pos_gates <- FALSE
+
 # Can vary these later.
 bandwidth_ncell_upper_vec <- c(2.5e3, 5e3, 1e4, 2e4, 5e4, 1e5, 2e5, 5e5, Inf)
 bandwidth_ncell_lower_vec <- c(0, 10, 20, 30, 50, 100, 200, 500, 1e3)
@@ -389,7 +397,9 @@ for (i in seq_len(nrow(sim_grid))) {
       sim_grid$n_cell_uns_relative_to_stim[i],
     covEvMin = 1.5,
     covEvMax = 1.5,
-    tolClust = NULL
+    tolClust = tol_clust,
+    locEnforceShapeThreshold = loc_enforce_shape_threshold,
+    calcCytPosGates = calc_cyt_pos_gates
   ) |>
     dplyr::mutate(
       transformation = sim_grid$transformation[i],
@@ -633,7 +643,9 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
               ncellUnsRelativeToStim = n_cell_uns_relative_to_stim,
               covEvMin = 1.5,
               covEvMax = 1.5,
-              tolClust = NULL
+              tolClust = tol_clust,
+              locEnforceShapeThreshold = loc_enforce_shape_threshold,
+              calcCytPosGates = calc_cyt_pos_gates
             ) |>
               dplyr::mutate(
                 transformation = transformation,

--- a/scripts/r/sim-bandwidth.R
+++ b/scripts/r/sim-bandwidth.R
@@ -331,6 +331,7 @@
   gateQuant = c(0.25, 0.75),
   locProbCol = "pred",
   locMinPeakProb = 0.25,
+  locEnforceShapeThreshold = FALSE,
   locDipAlpha = 0.2,
   locAntimodeHeightFrac = 1 / 6,
   locAntimodeLowRel = 0.25,
@@ -457,6 +458,7 @@
       tolClust = tolClust,
       locProbCol = locProbCol,
       locMinPeakProb = locMinPeakProb,
+      locEnforceShapeThreshold = locEnforceShapeThreshold,
       locDipAlpha = locDipAlpha,
       locAntimodeHeightFrac = locAntimodeHeightFrac,
       locAntimodeLowRel = locAntimodeLowRel,
@@ -633,6 +635,9 @@
         bwNcellMin = bwNcellMin,
         bwNcellMax = bwNcellMax,
         bwCluster = if (is.null(bwCluster)) NA_real_ else bwCluster,
+        tolClust = if (is.null(tolClust)) NA_real_ else tolClust,
+        locEnforceShapeThreshold = locEnforceShapeThreshold,
+        calcCytPosGates = calcCytPosGates,
         samplePerturbationSd = samplePerturbationSd,
         conditionPerturbationSd = conditionPerturbationSd,
         clusterPerturbationSd = clusterPerturbationSd,
@@ -817,6 +822,7 @@
   covEvMin = 1,
   covEvMax = 2,
   tolClust = 1e-7,
+  locEnforceShapeThreshold = FALSE,
   markerToPlot = "MarkerF1" # Specify univariate marker here
 ) {
   bwMtdGate <- .simBandwidthAdaptiveBwMtd(
@@ -916,7 +922,8 @@
       bwNcellMin = bwNcellMin,
       bwNcellMax = bwNcellMax,
       bwCluster = bwCluster,
-      tolClust = tolClust
+      tolClust = tolClust,
+      locEnforceShapeThreshold = locEnforceShapeThreshold
     ))
 
     # 5. Extract plots for each sample

--- a/scripts/r/sim-bw-adaptive.R
+++ b/scripts/r/sim-bw-adaptive.R
@@ -716,6 +716,9 @@
   bwAdaptiveCrossover,
   bwAdaptiveTransitionWidth,
   sim_id,
+  tolClust = tol_clust,
+  locEnforceShapeThreshold = FALSE,
+  calcCytPosGates = calc_cyt_pos_gates,
   nSample = n_sample_run,
   nIter = n_iter_run,
   nMarker = n_marker_run,
@@ -848,7 +851,9 @@
       minCell = min_cell,
       maxPosProbX = max_pos_prob_x,
       gateCombn = gate_combn,
-      tolClust = tol_clust
+      tolClust = tolClust,
+      locEnforceShapeThreshold = locEnforceShapeThreshold,
+      calcCytPosGates = calcCytPosGates
     ))
 
     truth_tbl <- .truth_from_labels(
@@ -905,6 +910,9 @@
         bwAdaptiveExtra = bwAdaptiveExtra %||% NA_real_,
         bwAdaptiveCrossover = bwAdaptiveCrossover %||% NA_real_,
         bwAdaptiveTransitionWidth = bwAdaptiveTransitionWidth %||% NA_real_,
+        tolClust = tolClust %||% NA_real_,
+        locEnforceShapeThreshold = locEnforceShapeThreshold,
+        calcCytPosGates = calcCytPosGates,
         sim_id = sim_id
       ) |>
       dplyr::select(

--- a/scripts/r/sim-compare-freq_bs.R
+++ b/scripts/r/sim-compare-freq_bs.R
@@ -621,6 +621,7 @@
   locTolRefPeak = "highest",
   gateCombn = "min",
   tolClust = NULL,
+  locEnforceShapeThreshold = FALSE,
   calcCytPosGates = FALSE,
   includeLocCondition = TRUE
 ) {
@@ -673,6 +674,7 @@
         tolClust = tolClust,
         locProbCol = locProbCol,
         locMinPeakProb = locMinPeakProb,
+        locEnforceShapeThreshold = locEnforceShapeThreshold,
         locDipAlpha = locDipAlpha,
         locAntimodeHeightFrac = locAntimodeHeightFrac,
         locAntimodeLowRel = locAntimodeLowRel,
@@ -818,6 +820,7 @@
   covEvMin = 1,
   covEvMax = 2,
   tolClust = NULL,
+  locEnforceShapeThreshold = FALSE,
   minCell = 1e2,
   maxPosProbX = Inf,
   gateQuant = c(0.25, 0.75),
@@ -977,6 +980,7 @@
       locTolRefPeak = locTolRefPeak,
       gateCombn = gateCombn,
       tolClust = tolClust,
+      locEnforceShapeThreshold = locEnforceShapeThreshold,
       calcCytPosGates = calcCytPosGates,
       includeLocCondition = includeLocCondition
     )
@@ -1023,6 +1027,9 @@
         bwNcellMin = bwNcellMin,
         bwNcellMax = bwNcellMax,
         bwCluster = bwCluster %||% NA_real_,
+        tolClust = tolClust %||% NA_real_,
+        locEnforceShapeThreshold = locEnforceShapeThreshold,
+        calcCytPosGates = calcCytPosGates,
         samplePerturbationSd = samplePerturbationSd,
         conditionPerturbationSd = conditionPerturbationSd,
         clusterPerturbationSd = clusterPerturbationSd,
@@ -1070,6 +1077,8 @@
   covEvMin = 2,
   covEvMax = 2,
   tolClust = NULL,
+  locEnforceShapeThreshold = FALSE,
+  calcCytPosGates = FALSE,
   includeLocCondition = TRUE,
   ...
 ) {
@@ -1100,6 +1109,8 @@
       covEvMin = covEvMin,
       covEvMax = covEvMax,
       tolClust = tolClust,
+      locEnforceShapeThreshold = locEnforceShapeThreshold,
+      calcCytPosGates = calcCytPosGates,
       includeLocCondition = includeLocCondition,
       ...
     )


### PR DESCRIPTION
Audited simulation wrapper parameters against the current gateStim() API, exposed locEnforceShapeThreshold across simulation helpers, centralised analysis choices across QMDs (keeping tolClust = NULL for bandwidth isolation and tolClust = 1e-7 for the method comparison), and recorded run configuration provenance in saved result data frames.

---
*PR created automatically by Jules for task [12334679620867218595](https://jules.google.com/task/12334679620867218595) started by @MiguelRodo*