### PR TITLE
Synchronise direct bandwidth simulation helpers with bandwidth implementation

### DIFF
--- a/scripts/r/sim-bandwidth.R
+++ b/scripts/r/sim-bandwidth.R
@@ -1011,6 +1011,17 @@
   covEvMax = 2,
   excMin = TRUE,
   capStimRange = TRUE,
+  normPeakFrac = 0.1,
+  normPeakMinRel = 0.75,
+  normExtraFrac = 0.2,
+  normExtraMax = Inf,
+  normExtraJitterFrac = 0.25,
+  normLambda = seq(-2, 2, length.out = 81),
+  normDensityN = 512L,
+  normExcessBwMtd = "hpi3",
+  normExcessNcell = 10000L,
+  normAdaptiveNcell = 2500L,
+  normMtd = "moments",
   summarise = TRUE
 ) {
   if (!identical(as.integer(nMarker), 1L)) {
@@ -1095,7 +1106,18 @@
         bwAdj = bwAdj,
         bwNcellMin = bwNcellMin,
         bwNcellMax = bwNcellMax,
-        bwFallback = bwFallback
+        bwFallback = bwFallback,
+        normPeakFrac = normPeakFrac,
+        normPeakMinRel = normPeakMinRel,
+        normExtraFrac = normExtraFrac,
+        normExtraMax = normExtraMax,
+        normExtraJitterFrac = normExtraJitterFrac,
+        normLambda = normLambda,
+        normDensityN = normDensityN,
+        normExcessBwMtd = normExcessBwMtd,
+        normExcessNcell = normExcessNcell,
+        normAdaptiveNcell = normAdaptiveNcell,
+        normMtd = normMtd
       )
 
       bw_stim <- .simBandwidthRemoveFallbackBw(
@@ -1111,7 +1133,18 @@
         bwAdj = bwAdj,
         bwNcellMin = bwNcellMin,
         bwNcellMax = bwNcellMax,
-        bwFallback = bwFallback
+        bwFallback = bwFallback,
+        normPeakFrac = normPeakFrac,
+        normPeakMinRel = normPeakMinRel,
+        normExtraFrac = normExtraFrac,
+        normExtraMax = normExtraMax,
+        normExtraJitterFrac = normExtraJitterFrac,
+        normLambda = normLambda,
+        normDensityN = normDensityN,
+        normExcessBwMtd = normExcessBwMtd,
+        normExcessNcell = normExcessNcell,
+        normAdaptiveNcell = normAdaptiveNcell,
+        normMtd = normMtd
       )
 
       bw_uns <- .simBandwidthRemoveFallbackBw(
@@ -1205,6 +1238,21 @@
   covEvMax = 2,
   excMin = TRUE,
   capStimRange = TRUE,
+  normPeakFrac = 0.1,
+  normPeakMinRel = 0.75,
+  normExtraFrac = 0.2,
+  normExtraMax = Inf,
+  normExtraJitterFrac = 0.25,
+  normLambda = seq(-2, 2, length.out = 81),
+  normDensityN = 512L,
+  normExcessBwMtd = "hpi3",
+  normExcessNcell = 10000L,
+  normAdaptiveNcell = 2500L,
+  bwAdaptiveCore = NULL,
+  bwAdaptiveExtra = NULL,
+  bwAdaptiveCrossover = NULL,
+  bwAdaptiveTransitionWidth = 0,
+  normMtd = "moments",
   summarise = FALSE
 ) {
   if (!identical(as.integer(nMarker), 1L)) {
@@ -1305,7 +1353,22 @@
           bwAdj = bwAdj,
           bwNcellMin = bwNcellMin,
           bwNcellMax = bwNcellMax,
-          bwFallback = bwFallback
+          bwFallback = bwFallback,
+          normPeakFrac = normPeakFrac,
+          normPeakMinRel = normPeakMinRel,
+          normExtraFrac = normExtraFrac,
+          normExtraMax = normExtraMax,
+          normExtraJitterFrac = normExtraJitterFrac,
+          normLambda = normLambda,
+          normDensityN = normDensityN,
+          normExcessBwMtd = normExcessBwMtd,
+          normExcessNcell = normExcessNcell,
+          normAdaptiveNcell = normAdaptiveNcell,
+          bwAdaptiveCore = bwAdaptiveCore,
+          bwAdaptiveExtra = bwAdaptiveExtra,
+          bwAdaptiveCrossover = bwAdaptiveCrossover,
+          bwAdaptiveTransitionWidth = bwAdaptiveTransitionWidth,
+          normMtd = normMtd
         )
       )
       bwStimCore <- tryCatch(bwObj$bw$stim$bwCore, error = function(e) NA_real_)
@@ -1524,7 +1587,23 @@
   bwAdj,
   bwNcellMin,
   bwNcellMax,
-  bwFallback
+  bwFallback,
+  normPeakFrac = 0.1,
+  normPeakMinRel = 0.75,
+  normExtraFrac = 0.2,
+  normExtraMax = Inf,
+  normExtraJitterFrac = 0.25,
+  normLambda = seq(-2, 2, length.out = 81),
+  normDensityN = 512L,
+  normExcessBwMtd = "hpi3",
+  normExcessNcell = 10000L,
+  normAdaptiveNcell = 2500L,
+  bwAdaptiveCore = NULL,
+  bwAdaptiveExtra = NULL,
+  bwAdaptiveCrossover = NULL,
+  bwAdaptiveTransitionWidth = 0,
+  normMtd = "moments",
+  adaptive = FALSE
 ) {
   x <- suppressWarnings(as.numeric(x))
   x <- x[is.finite(x)]
@@ -1541,7 +1620,23 @@
           bwMtd = bwMtd,
           bwAdj = bwAdj,
           bwNcellMin = bwNcellMin,
-          bwNcellMax = bwNcellMax
+          bwNcellMax = bwNcellMax,
+          normPeakFrac = normPeakFrac,
+          normPeakMinRel = normPeakMinRel,
+          normExtraFrac = normExtraFrac,
+          normExtraMax = normExtraMax,
+          normExtraJitterFrac = normExtraJitterFrac,
+          normLambda = normLambda,
+          normDensityN = normDensityN,
+          normExcessBwMtd = normExcessBwMtd,
+          normExcessNcell = normExcessNcell,
+          normAdaptiveNcell = normAdaptiveNcell,
+          bwAdaptiveCore = bwAdaptiveCore,
+          bwAdaptiveExtra = bwAdaptiveExtra,
+          bwAdaptiveCrossover = bwAdaptiveCrossover,
+          bwAdaptiveTransitionWidth = bwAdaptiveTransitionWidth,
+          normMtd = normMtd,
+          adaptive = adaptive
         )
       } else {
         .simBandwidthBwOneBaseLegacy(

--- a/scripts/r/sim-bw-adaptive.R
+++ b/scripts/r/sim-bw-adaptive.R
@@ -175,35 +175,37 @@
   norm_excess_bw_mtd = "hpi3",
   norm_excess_ncell = 10000L,
   norm_adaptive_ncell = 2500L,
+  bw_adaptive_core = NULL,
+  bw_adaptive_extra = NULL,
+  bw_adaptive_crossover = NULL,
+  bw_adaptive_transition_width = 0,
   norm_mtd = "moments"
 ) {
   use_adaptive <- isTRUE(bw_adaptive) && grepl("Norm$", bw_mtd)
 
-  bw_args <- list(
-    x = x,
-    bwMtd = bw_mtd,
-    bwAdj = bw_adj,
-    bwNcellMin = bw_ncell_min,
-    bwNcellMax = bw_ncell_max,
-    normPeakFrac = norm_peak_frac,
-    normPeakMinRel = norm_peak_min_rel,
-    normExtraFrac = norm_extra_frac,
-    normExtraMax = norm_extra_max,
-    normExtraJitterFrac = norm_extra_jitter_frac,
-    normDensityN = norm_density_n,
-    normExcessBwMtd = norm_excess_bw_mtd,
-    normExcessNcell = norm_excess_ncell,
-    normAdaptiveNcell = norm_adaptive_ncell,
-    normMtd = norm_mtd,
-    adaptive = use_adaptive
-  )
-
-  # Keeps the notebook usable if it is accidentally run against an older helper:
-  # unsupported arguments are dropped before calling .bwCalcOne().
-  bw_args <- bw_args[intersect(names(bw_args), names(formals(.bwCalcOne)))]
-
   out <- tryCatch(
-    do.call(.bwCalcOne, bw_args),
+    .bwCalcOne(
+      x = x,
+      bwMtd = bw_mtd,
+      bwAdj = bw_adj,
+      bwNcellMin = bw_ncell_min,
+      bwNcellMax = bw_ncell_max,
+      normPeakFrac = norm_peak_frac,
+      normPeakMinRel = norm_peak_min_rel,
+      normExtraFrac = norm_extra_frac,
+      normExtraMax = norm_extra_max,
+      normExtraJitterFrac = norm_extra_jitter_frac,
+      normDensityN = norm_density_n,
+      normExcessBwMtd = norm_excess_bw_mtd,
+      normExcessNcell = norm_excess_ncell,
+      normAdaptiveNcell = norm_adaptive_ncell,
+      bwAdaptiveCore = bw_adaptive_core,
+      bwAdaptiveExtra = bw_adaptive_extra,
+      bwAdaptiveCrossover = bw_adaptive_crossover,
+      bwAdaptiveTransitionWidth = bw_adaptive_transition_width,
+      normMtd = norm_mtd,
+      adaptive = use_adaptive
+    ),
     error = function(e) {
       structure(NA_real_, error = e$message)
     }

--- a/tests/testthat/test-analysis-helpers.R
+++ b/tests/testthat/test-analysis-helpers.R
@@ -39,3 +39,80 @@ test_that("analysis helpers do not expose or forward calcSinglePosGates", {
   expect_s3_class(res, "data.frame")
   expect_true(nrow(res) > 0)
 })
+
+test_that("direct bandwidth simulation helpers agree numerically with package implementation", {
+  skip_if_not_installed("stimgate")
+
+  root_dir <- testthat::test_path("../..")
+  script_misc <- file.path(root_dir, "scripts", "r", "sim-misc.R")
+  script_bw <- file.path(root_dir, "scripts", "r", "sim-bandwidth.R")
+  script_adaptive <- file.path(root_dir, "scripts", "r", "sim-bw-adaptive.R")
+
+  skip_if_not(file.exists(script_bw), "sim-bandwidth.R not found")
+  skip_if_not(file.exists(script_adaptive), "sim-bw-adaptive.R not found")
+
+  source(script_misc, local = TRUE)
+  source(script_bw, local = TRUE)
+  source(script_adaptive, local = TRUE)
+
+  set.seed(42)
+  x_sample <- rnorm(200, mean = 5, sd = 1.5)
+
+  # Check standard normalized bandwidth via .simBandwidthBwOne vs .bwCalcOne
+  bw_direct_std <- .simBandwidthBwOne(
+    x = x_sample,
+    bwMtd = "hpi1Norm",
+    bwMin = 1e-10,
+    bwMax = 1e10,
+    bwAdj = 1,
+    bwNcellMin = 10L,
+    bwNcellMax = 1000L,
+    bwFallback = NULL,
+    normPeakFrac = 0.15,
+    normExtraFrac = 0.25
+  )
+
+  bw_pkg_std <- stimgate:::.bwCalcOne(
+    x = x_sample,
+    bwMtd = "hpi1Norm",
+    bwAdj = 1,
+    bwNcellMin = 10L,
+    bwNcellMax = 1000L,
+    normPeakFrac = 0.15,
+    normExtraFrac = 0.25,
+    adaptive = FALSE
+  )
+
+  expect_equal(as.numeric(bw_direct_std), as.numeric(bw_pkg_std))
+
+  # Check adaptive normalized bandwidth via .bwDiagBwOne vs .bwCalcOne
+  set.seed(42)
+  bw_diag_adapt <- .bwDiagBwOne(
+    x = x_sample,
+    bw_mtd = "hpi1Norm",
+    bw_adaptive = TRUE,
+    bw_adj = 1,
+    bw_ncell_min = 10L,
+    bw_ncell_max = 1000L,
+    norm_peak_frac = 0.15,
+    norm_extra_frac = 0.25
+  )
+
+  set.seed(42)
+  bw_pkg_adapt <- stimgate:::.bwCalcOne(
+    x = x_sample,
+    bwMtd = "hpi1Norm",
+    bwAdj = 1,
+    bwNcellMin = 10L,
+    bwNcellMax = 1000L,
+    normPeakFrac = 0.15,
+    normExtraFrac = 0.25,
+    adaptive = TRUE
+  )
+
+  expect_true(is.list(bw_diag_adapt))
+  expect_true(is.list(bw_pkg_adapt))
+  expect_equal(bw_diag_adapt$bw, bw_pkg_adapt$bw)
+  expect_equal(bw_diag_adapt$bwCore, bw_pkg_adapt$bwCore)
+  expect_equal(bw_diag_adapt$bwExtra, bw_pkg_adapt$bwExtra)
+})


### PR DESCRIPTION
Synchronise direct bandwidth simulation helpers in scripts/r/ with the package bandwidth implementation by explicitly forwarding normalisation and adaptive bandwidth parameters, removing silent argument-pruning shims, and adding numerical regression tests.

---
*PR created automatically by Jules for task [467175396645814323](https://jules.google.com/task/467175396645814323) started by @MiguelRodo*