### PR TITLE
Document coding agent setup for Jules and Codex

### DIFF
--- a/.github/workflows/analysis-integration.yaml
+++ b/.github/workflows/analysis-integration.yaml
@@ -51,7 +51,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::devtools, any::testthat, SATVILab/simcyto@734637f0a4568bbfebe8712e62c326921db2955d
+          # Deliberately unpinned: analysis validation follows the current
+          # SATVILab/simcyto default branch used by StimGate development.
+          extra-packages: any::devtools, any::testthat, SATVILab/simcyto
           needs: check
 
       - name: Run analysis integration tests

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -62,7 +62,9 @@ jobs:
             any::rcmdcheck
             any::devtools
             any::decor
-            SATVILab/simcyto@734637f0a4568bbfebe8712e62c326921db2955d
+            # Deliberately unpinned: StimGate development tracks the latest
+            # SATVILab/simcyto default branch.
+            SATVILab/simcyto
           needs: check
           # Save only a successfully completed package library. Cache version 4
           # starts a clean binary-backed cache using Posit Public Package Manager.

--- a/scripts/agents/maintenance-codex.sh
+++ b/scripts/agents/maintenance-codex.sh
@@ -1,0 +1,90 @@
+set -euxo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+export DEBIAN_FRONTEND=noninteractive
+export PKG_SYSREQS=true
+export PKG_SYSREQS_VERBOSE=true
+
+if [ "${CI:-}" != "true" ]; then
+    echo "ERROR: Configure CI=true as a persistent Codex environment variable."
+    exit 1
+fi
+
+R_MINOR="4.6"
+BIOC_VERSION="3.23"
+POSIT_CRAN="https://packagemanager.posit.co/cran/latest/bin/linux/noble-x86_64/${R_MINOR}"
+
+cat > /tmp/stimgate-agent-repos.R <<EOF
+options(
+    repos = {
+        repos <- BiocManager::repositories(version = "$BIOC_VERSION")
+        repos <- repos[!names(repos) %in% c("CRAN", "RSPM")]
+        c(repos, CRAN = "$POSIT_CRAN")
+    }
+)
+EOF
+
+if ! Rscript --vanilla -e 'quit(status = if (requireNamespace("pak", quietly = TRUE)) 0 else 1)'; then
+    sudo env CI=true Rscript --vanilla -e '
+    install.packages(
+        "pak",
+        repos = sprintf(
+            "https://r-lib.github.io/p/pak/stable/%s/%s/%s",
+            .Platform$pkgType,
+            R.Version()$os,
+            R.Version()$arch
+        )
+    )
+    '
+fi
+
+# Pick up any newly declared StimGate dependencies without broadly upgrading
+# the whole cached environment.
+sudo env CI=true PKG_SYSREQS=true PKG_SYSREQS_VERBOSE=true \
+    Rscript --vanilla -e '
+source("/tmp/stimgate-agent-repos.R")
+pak::local_install_dev_deps(".", upgrade = FALSE, ask = FALSE)
+'
+
+# simcyto deliberately tracks the current SATVILab default branch. It is not
+# pinned because StimGate development normally targets the latest simcyto API.
+sudo env CI=true PKG_SYSREQS=true PKG_SYSREQS_VERBOSE=true \
+    Rscript --vanilla -e '
+source("/tmp/stimgate-agent-repos.R")
+pak::pkg_install("SATVILab/simcyto", upgrade = TRUE, ask = FALSE)
+'
+
+# Ensure repository-wide tools that are intentionally outside DESCRIPTION are
+# still available. Do not force upgrades for these on every maintenance run.
+sudo env CI=true PKG_SYSREQS=true PKG_SYSREQS_VERBOSE=true \
+    Rscript --vanilla -e '
+source("/tmp/stimgate-agent-repos.R")
+pak::pkg_install(
+    c(
+        "devtools", "rcmdcheck", "decor", "roxygen2", "styler", "lintr", "covr", "pkgdown",
+        "SATVILab/projr",
+        "future", "furrr", "progressr",
+        "reticulate",
+        "RGLab/cytoUtils"
+    ),
+    upgrade = FALSE,
+    ask = FALSE
+)
+'
+
+Rscript --vanilla -e '
+required <- c(
+    "flowCore", "flowWorkspace", "Biobase", "testthat", "devtools",
+    "projr", "simcyto", "future", "furrr", "progressr", "reticulate", "cytoUtils"
+)
+ok <- vapply(required, requireNamespace, logical(1), quietly = TRUE)
+if (!all(ok)) stop("Codex maintenance left packages missing: ", paste(required[!ok], collapse = ", "))
+stopifnot(identical(Sys.getenv("CI"), "true"))
+devtools::load_all()
+sim_desc <- utils::packageDescription("simcyto")
+cat("StimGate Codex maintenance complete\n")
+cat("simcyto: ", as.character(sim_desc[["Version"]]), "\n", sep = "")
+if (!is.null(sim_desc[["RemoteSha"]])) cat("simcyto GitHub SHA: ", sim_desc[["RemoteSha"]], "\n", sep = "")
+cat("stimgate loaded successfully\n")
+'

--- a/scripts/agents/setup-codex.sh
+++ b/scripts/agents/setup-codex.sh
@@ -1,0 +1,164 @@
+set -euxo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+export DEBIAN_FRONTEND=noninteractive
+export PKG_SYSREQS=true
+export PKG_SYSREQS_VERBOSE=true
+
+if [ "${CI:-}" != "true" ]; then
+    echo "ERROR: Configure CI=true as a persistent Codex environment variable."
+    exit 1
+fi
+
+R_MINOR="4.6"
+BIOC_VERSION="3.23"
+POSIT_CRAN="https://packagemanager.posit.co/cran/latest/bin/linux/noble-x86_64/${R_MINOR}"
+
+sudo apt-get update -qq
+sudo apt-get install --no-install-recommends -y \
+    ca-certificates curl dirmngr gnupg lsb-release software-properties-common wget git \
+    libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libgit2-dev \
+    libjpeg-dev libpng-dev libx11-dev libssl-dev libxml2-dev pandoc \
+    python3 python3-numpy
+
+wget -qO /tmp/cran_ubuntu_key.asc \
+    https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc
+sudo install -m 0644 /tmp/cran_ubuntu_key.asc /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+sudo add-apt-repository -y \
+    "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
+sudo apt-get update -qq
+sudo apt-get install --no-install-recommends -y r-base r-base-dev
+
+Rscript --vanilla -e "
+expected <- '${R_MINOR}'
+actual <- paste(R.version\$major, sub('\\\\..*$', '', R.version\$minor), sep = '.')
+if (!identical(actual, expected)) stop('Expected R ', expected, '.x but found ', R.version.string)
+cat('Using ', R.version.string, '\n', sep = '')
+"
+
+sudo env CI=true Rscript --vanilla -e "
+options(repos = c(CRAN = '${POSIT_CRAN}'))
+if (!requireNamespace('BiocManager', quietly = TRUE)) install.packages('BiocManager')
+BiocManager::install(version = '${BIOC_VERSION}', ask = FALSE, update = FALSE)
+cat('Bioconductor version: ', as.character(BiocManager::version()), '\n', sep = '')
+"
+
+sudo env CI=true Rscript --vanilla -e '
+install.packages(
+    "pak",
+    repos = sprintf(
+        "https://r-lib.github.io/p/pak/stable/%s/%s/%s",
+        .Platform$pkgType,
+        R.Version()$os,
+        R.Version()$arch
+    )
+)
+'
+
+cat > /tmp/stimgate-agent-repos.R <<EOF
+options(
+    repos = {
+        repos <- BiocManager::repositories(version = "$BIOC_VERSION")
+        repos <- repos[!names(repos) %in% c("CRAN", "RSPM")]
+        c(repos, CRAN = "$POSIT_CRAN")
+    }
+)
+EOF
+
+# Install the latest stable Quarto release. Avoid pinning the cloud environment
+# to an obsolete Quarto release while still using a deterministic release asset.
+QUARTO_VERSION="$(curl -fsSL https://api.github.com/repos/quarto-dev/quarto-cli/releases/latest \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"].lstrip("v"))')"
+wget -qO /tmp/quarto.deb \
+    "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.deb"
+sudo dpkg -i /tmp/quarto.deb
+rm -f /tmp/quarto.deb
+quarto --version
+
+run_pak_pass() {
+    local rc=0
+
+    sudo env CI=true PKG_SYSREQS=true PKG_SYSREQS_VERBOSE=true \
+        Rscript --vanilla -e '
+    source("/tmp/stimgate-agent-repos.R")
+    pak::local_install_dev_deps(".", upgrade = FALSE, ask = FALSE)
+    ' || rc=1
+
+    sudo env CI=true PKG_SYSREQS=true PKG_SYSREQS_VERBOSE=true \
+        Rscript --vanilla -e '
+    source("/tmp/stimgate-agent-repos.R")
+    pak::pkg_install(
+        c(
+            "devtools", "rcmdcheck", "decor", "roxygen2", "styler", "lintr", "covr", "pkgdown",
+            "SATVILab/projr",
+            "SATVILab/simcyto",
+            "future", "furrr", "progressr",
+            "reticulate",
+            "RGLab/cytoUtils"
+        ),
+        upgrade = FALSE,
+        ask = FALSE
+    )
+    ' || rc=1
+
+    return "$rc"
+}
+
+run_bioc_repair() {
+    sudo env CI=true Rscript --vanilla -e "
+    source('/tmp/stimgate-agent-repos.R')
+    BiocManager::install(
+        c('flowCore', 'flowWorkspace', 'Biobase'),
+        version = '${BIOC_VERSION}',
+        ask = FALSE,
+        update = FALSE
+    )
+    "
+}
+
+if run_pak_pass; then
+    PAK_PASS_1=0
+else
+    PAK_PASS_1=$?
+fi
+
+if [ "$PAK_PASS_1" -ne 0 ]; then
+    run_bioc_repair || true
+fi
+
+if run_pak_pass; then
+    PAK_PASS_2=0
+else
+    PAK_PASS_2=$?
+fi
+
+if [ "$PAK_PASS_2" -ne 0 ]; then
+    sudo env CI=true PKG_SYSREQS=true PKG_SYSREQS_VERBOSE=true \
+        Rscript --vanilla -e '
+    source("/tmp/stimgate-agent-repos.R")
+    try(pak::sysreqs_fix_installed(), silent = FALSE)
+    ' || true
+    run_bioc_repair || true
+    run_pak_pass || true
+fi
+
+Rscript --vanilla -e '
+required <- c(
+    "flowCore", "flowWorkspace", "Biobase",
+    "testthat", "devtools", "rcmdcheck", "decor", "roxygen2", "styler", "lintr", "covr", "pkgdown",
+    "projr", "simcyto", "future", "furrr", "progressr", "reticulate", "cytoUtils"
+)
+ok <- vapply(required, requireNamespace, logical(1), quietly = TRUE)
+if (!all(ok)) stop("Codex R environment is incomplete. Missing: ", paste(required[!ok], collapse = ", "))
+stopifnot(identical(Sys.getenv("CI"), "true"))
+devtools::load_all()
+cat("StimGate Codex environment ready\n")
+cat("R: ", R.version.string, "\n", sep = "")
+cat("Bioconductor: ", as.character(BiocManager::version()), "\n", sep = "")
+sim_desc <- utils::packageDescription("simcyto")
+cat("simcyto: ", as.character(sim_desc[["Version"]]), "\n", sep = "")
+if (!is.null(sim_desc[["RemoteSha"]])) cat("simcyto GitHub SHA: ", sim_desc[["RemoteSha"]], "\n", sep = "")
+'
+
+quarto check

--- a/scripts/agents/setup-jules.sh
+++ b/scripts/agents/setup-jules.sh
@@ -1,0 +1,158 @@
+set -euxo pipefail
+
+# Jules currently checks the repository out under /app.
+cd /app
+
+export CI=true
+export DEBIAN_FRONTEND=noninteractive
+export PKG_SYSREQS=true
+export PKG_SYSREQS_VERBOSE=true
+
+R_MINOR="4.6"
+BIOC_VERSION="3.23"
+POSIT_CRAN="https://packagemanager.posit.co/cran/latest/bin/linux/noble-x86_64/${R_MINOR}"
+
+sudo apt-get update -qq
+sudo apt-get install --no-install-recommends -y \
+    ca-certificates curl dirmngr gnupg lsb-release software-properties-common wget git \
+    libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libgit2-dev \
+    libjpeg-dev libpng-dev libx11-dev libssl-dev libxml2-dev pandoc \
+    python3 python3-numpy
+
+wget -qO /tmp/cran_ubuntu_key.asc \
+    https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc
+sudo install -m 0644 /tmp/cran_ubuntu_key.asc /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+sudo add-apt-repository -y \
+    "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
+sudo apt-get update -qq
+sudo apt-get install --no-install-recommends -y r-base r-base-dev
+
+Rscript --vanilla -e "
+expected <- '${R_MINOR}'
+actual <- paste(R.version\$major, sub('\\\\..*$', '', R.version\$minor), sep = '.')
+if (!identical(actual, expected)) stop('Expected R ', expected, '.x but found ', R.version.string)
+cat('Using ', R.version.string, '\n', sep = '')
+"
+
+sudo env CI=true Rscript --vanilla -e "
+options(repos = c(CRAN = '${POSIT_CRAN}'))
+if (!requireNamespace('BiocManager', quietly = TRUE)) install.packages('BiocManager')
+BiocManager::install(version = '${BIOC_VERSION}', ask = FALSE, update = FALSE)
+cat('Bioconductor version: ', as.character(BiocManager::version()), '\n', sep = '')
+"
+
+sudo env CI=true Rscript --vanilla -e '
+install.packages(
+    "pak",
+    repos = sprintf(
+        "https://r-lib.github.io/p/pak/stable/%s/%s/%s",
+        .Platform$pkgType,
+        R.Version()$os,
+        R.Version()$arch
+    )
+)
+'
+
+cat > /tmp/stimgate-agent-repos.R <<EOF
+options(
+    repos = {
+        repos <- BiocManager::repositories(version = "$BIOC_VERSION")
+        repos <- repos[!names(repos) %in% c("CRAN", "RSPM")]
+        c(repos, CRAN = "$POSIT_CRAN")
+    }
+)
+EOF
+
+QUARTO_VERSION="$(curl -fsSL https://api.github.com/repos/quarto-dev/quarto-cli/releases/latest \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"].lstrip("v"))')"
+wget -qO /tmp/quarto.deb \
+    "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.deb"
+sudo dpkg -i /tmp/quarto.deb
+rm -f /tmp/quarto.deb
+quarto --version
+
+run_pak_pass() {
+    local rc=0
+
+    sudo env CI=true PKG_SYSREQS=true PKG_SYSREQS_VERBOSE=true \
+        Rscript --vanilla -e '
+    source("/tmp/stimgate-agent-repos.R")
+    pak::local_install_dev_deps(".", upgrade = FALSE, ask = FALSE)
+    ' || rc=1
+
+    sudo env CI=true PKG_SYSREQS=true PKG_SYSREQS_VERBOSE=true \
+        Rscript --vanilla -e '
+    source("/tmp/stimgate-agent-repos.R")
+    pak::pkg_install(
+        c(
+            "devtools", "rcmdcheck", "decor", "roxygen2", "styler", "lintr", "covr", "pkgdown",
+            "SATVILab/projr",
+            "SATVILab/simcyto",
+            "future", "furrr", "progressr",
+            "reticulate",
+            "RGLab/cytoUtils"
+        ),
+        upgrade = FALSE,
+        ask = FALSE
+    )
+    ' || rc=1
+
+    return "$rc"
+}
+
+run_bioc_repair() {
+    sudo env CI=true Rscript --vanilla -e "
+    source('/tmp/stimgate-agent-repos.R')
+    BiocManager::install(
+        c('flowCore', 'flowWorkspace', 'Biobase'),
+        version = '${BIOC_VERSION}',
+        ask = FALSE,
+        update = FALSE
+    )
+    "
+}
+
+if run_pak_pass; then
+    PAK_PASS_1=0
+else
+    PAK_PASS_1=$?
+fi
+
+if [ "$PAK_PASS_1" -ne 0 ]; then
+    run_bioc_repair || true
+fi
+
+if run_pak_pass; then
+    PAK_PASS_2=0
+else
+    PAK_PASS_2=$?
+fi
+
+if [ "$PAK_PASS_2" -ne 0 ]; then
+    sudo env CI=true PKG_SYSREQS=true PKG_SYSREQS_VERBOSE=true \
+        Rscript --vanilla -e '
+    source("/tmp/stimgate-agent-repos.R")
+    try(pak::sysreqs_fix_installed(), silent = FALSE)
+    ' || true
+    run_bioc_repair || true
+    run_pak_pass || true
+fi
+
+Rscript --vanilla -e '
+required <- c(
+    "flowCore", "flowWorkspace", "Biobase",
+    "testthat", "devtools", "rcmdcheck", "decor", "roxygen2", "styler", "lintr", "covr", "pkgdown",
+    "projr", "simcyto", "future", "furrr", "progressr", "reticulate", "cytoUtils"
+)
+ok <- vapply(required, requireNamespace, logical(1), quietly = TRUE)
+if (!all(ok)) stop("Jules R environment is incomplete. Missing: ", paste(required[!ok], collapse = ", "))
+devtools::load_all()
+cat("StimGate Jules environment ready\n")
+cat("R: ", R.version.string, "\n", sep = "")
+cat("Bioconductor: ", as.character(BiocManager::version()), "\n", sep = "")
+sim_desc <- utils::packageDescription("simcyto")
+cat("simcyto: ", as.character(sim_desc[["Version"]]), "\n", sep = "")
+if (!is.null(sim_desc[["RemoteSha"]])) cat("simcyto GitHub SHA: ", sim_desc[["RemoteSha"]], "\n", sep = "")
+'
+
+quarto check

--- a/vignettes/coding-agents.Rmd
+++ b/vignettes/coding-agents.Rmd
@@ -22,8 +22,9 @@ This guide currently covers:
 
 - Google Jules
 - OpenAI Codex Cloud
+- GitHub Copilot coding agent
 
-The repository-level instructions for coding agents live in `AGENTS.md`. Agents should read that file before changing code. The environment scripts described below are kept under `scripts/agents/` so that the setup is version-controlled alongside the package rather than copied independently between agent products.
+The repository-level instructions for coding agents live in `AGENTS.md`. Agents should read that file before changing code. The environment scripts described below are kept under `scripts/agents/` where appropriate so that the setup is version-controlled alongside the package rather than copied independently between agent products.
 
 The recommended cloud-agent environment is deliberately different from ordinary local development. In local development, StimGate may activate an `renv` profile through `.Rprofile`. Cloud agents instead use a directly installed development library and should run with `CI=true`, which tells the repository not to activate `renv`.
 
@@ -37,15 +38,17 @@ The current setup targets:
 - development tools such as `devtools`, `rcmdcheck`, `roxygen2`, `styler`, `lintr`, `covr` and `pkgdown`
 - analysis dependencies used by the simulation and comparison workflows, including `future`, `furrr`, `progressr`, `reticulate` and `cytoUtils`
 
-`simcyto` is intentionally not pinned to a commit. StimGate development normally targets the latest version in `SATVILab/simcyto`, and the Codex maintenance script explicitly refreshes it.
+`simcyto` is intentionally not pinned to a commit. StimGate development normally targets the latest version in `SATVILab/simcyto`. Codex maintenance explicitly refreshes it, and the Copilot and analysis GitHub Actions workflows install the unpinned repository package.
 
 # Shared principles
 
-## Prefer repository scripts over duplicated UI scripts
+## Prefer repository scripts or workflows over duplicated UI scripts
 
-The recommended approach is to make the agent UI call the script from the checked-out repository. This keeps the authoritative setup in Git, makes changes reviewable, and avoids having different Jules, Codex and documentation copies drift apart.
+The recommended approach is to make the agent platform use configuration stored in the repository whenever possible. This keeps the authoritative setup in Git, makes changes reviewable, and avoids having different Jules, Codex and documentation copies drift apart.
 
-If an agent product only accepts pasted setup text, copy the current contents of the corresponding file under `scripts/agents/`.
+For Codex and Jules, repository setup scripts live under `scripts/agents/`. GitHub Copilot uses the repository workflow `.github/workflows/copilot-setup-steps.yml` directly.
+
+If an agent product only accepts pasted setup text, copy the current contents of the corresponding repository file rather than maintaining a separate unmanaged version.
 
 ## Do not restore `renv` in the cloud-agent environment
 
@@ -69,16 +72,18 @@ SATVILab/simcyto
 
 rather than a commit-pinned package specification unless a particular historical analysis explicitly requires an old API.
 
+This rule also applies to CI and coding-agent setup. A stale `simcyto` pin can make the agent test StimGate against an API that is no longer the one used by current development.
+
 ## Validate the environment, not just the installer exit code
 
-Both setup scripts finish by checking that the important packages are actually available and that:
+The setup environments finish by checking that the important packages are actually available and that:
 
 ```r
 #| eval: false
 devtools::load_all()
 ```
 
-succeeds. Intermediate package-install failures may be recoverable, especially for Bioconductor dependencies, so the scripts use a pak-first, Bioconductor-repair, pak-again strategy before applying the final hard checks.
+succeeds. Intermediate package-install failures may be recoverable, especially for Bioconductor dependencies, so the Codex and Jules scripts use a pak-first, Bioconductor-repair, pak-again strategy before applying the final hard checks.
 
 # OpenAI Codex Cloud
 
@@ -112,7 +117,7 @@ The full script is stored at:
 scripts/agents/setup-codex.sh
 ```
 
-It installs R and Bioconductor, the system libraries required by the package, the latest stable Quarto release, StimGate's development dependencies, the latest `SATVILab/simcyto`, and the additional analysis tooling used by the repository.
+It installs R and Bioconductor, the system libraries required by the package, Quarto, StimGate's development dependencies, the latest `SATVILab/simcyto`, and the additional analysis tooling used by the repository.
 
 ## Maintenance script
 
@@ -201,7 +206,7 @@ Jules needs access to the StimGate repository and to the package sources used du
 
 ## Keeping the environment current
 
-Jules does not currently use the Codex maintenance-script mechanism described above. When the environment is rebuilt, `setup-jules.sh` installs the latest `SATVILab/simcyto` rather than a pinned revision.
+When the Jules environment is rebuilt, `setup-jules.sh` installs the latest `SATVILab/simcyto` rather than a pinned revision.
 
 If a long-lived Jules environment becomes stale, rerun the setup or explicitly refresh the GitHub package from R:
 
@@ -210,11 +215,81 @@ If a long-lived Jules environment becomes stale, rerun the setup or explicitly r
 pak::pkg_install("SATVILab/simcyto", upgrade = TRUE, ask = FALSE)
 ```
 
+# GitHub Copilot coding agent
+
+## How StimGate configures Copilot
+
+The GitHub Copilot coding agent does not use the Codex or Jules setup scripts. Its environment is configured by the repository workflow:
+
+```text
+.github/workflows/copilot-setup-steps.yml
+```
+
+That file is the source of truth for Copilot's cloud environment. Keep Copilot environment changes there so that every Copilot task gets the same setup and the configuration remains reviewable in Git.
+
+The workflow currently:
+
+- installs the Linux system libraries needed by StimGate;
+- checks out the repository;
+- installs the current R release with Posit Package Manager enabled;
+- installs StimGate package and development dependencies;
+- installs `devtools`, `rcmdcheck` and `decor`;
+- installs the latest `SATVILab/simcyto` from its default branch;
+- verifies the important R packages and `devtools::load_all()`; and
+- installs Quarto.
+
+The repository `.Rprofile` treats the Copilot agent as CI, so Copilot should use the directly installed development library rather than running `renv::restore()`.
+
+## `simcyto` policy for Copilot
+
+Do not pin `simcyto` to a commit in `.github/workflows/copilot-setup-steps.yml`.
+
+The expected package specification is:
+
+```text
+SATVILab/simcyto
+```
+
+This ensures newly started Copilot tasks are built against the latest `simcyto` development API.
+
+The analysis integration workflow follows the same rule. `.github/workflows/analysis-integration.yaml` also installs unpinned `SATVILab/simcyto`, so Copilot, analysis CI and current StimGate development test the same moving dependency rather than different historical revisions.
+
+Pinning a SHA is only appropriate for a deliberately historical reproduction or version-regression task. If that is required, make the pin task-specific rather than changing the default Copilot setup.
+
+## Using Copilot on StimGate
+
+Before changing code, the agent should follow `AGENTS.md`, which defines the repository architecture, coding style, testing rules and which test suite to run for each kind of change.
+
+Typical package work can validate with:
+
+```bash
+Rscript -e "devtools::load_all(); devtools::test()"
+```
+
+Changes involving `analysis/` or `scripts/r/` should also run:
+
+```bash
+Rscript analysis/tests/run_analysis_tests.R
+```
+
+The Copilot setup workflow is intentionally closer to the GitHub Actions environment than to the heavier Codex/Jules scripts. That makes it fast enough for repeated cloud-agent tasks while still covering the normal package-development path.
+
+## Updating the Copilot environment
+
+When StimGate gains a new dependency:
+
+1. add ordinary package dependencies to `DESCRIPTION` where they belong;
+2. add agent-only or repository-wide development tools to `copilot-setup-steps.yml` only when they are genuinely needed for Copilot tasks;
+3. keep `SATVILab/simcyto` unpinned; and
+4. extend the verification step if the dependency is important enough that a missing installation should make the environment fail immediately.
+
+Avoid duplicating a large independent shell installer for Copilot unless the GitHub Actions setup becomes unable to express the required environment cleanly.
+
 # Alternative environment strategies
 
 ## Use the GitHub Actions environment as the minimal baseline
 
-The repository's GitHub Actions workflows are useful references for the minimum environment needed for package and analysis tests. They are deliberately more compact than the cloud-agent scripts. This is a good option when an agent only needs package tests and not the full range of research analyses.
+The repository's GitHub Actions workflows are useful references for the minimum environment needed for package and analysis tests. They are deliberately more compact than the Codex and Jules cloud-agent scripts. This is a good option when an agent only needs package tests and not the full range of research analyses.
 
 ## Use `renv` for local or long-lived interactive development
 
@@ -226,13 +301,13 @@ The agent environment normally follows the current `simcyto` repository. Pinning
 
 ## Reduce the environment for narrow tasks
 
-An agent working only on documentation or a small package function may not need Quarto, the comparison stack, or all analysis dependencies. A smaller environment can start faster. The full scripts are intentionally broad because the StimGate coding agents are expected to handle package code, tests and current analyses without frequent environment rebuilds.
+An agent working only on documentation or a small package function may not need Quarto, the comparison stack, or all analysis dependencies. A smaller environment can start faster. The full Codex and Jules scripts are intentionally broad because those agents are expected to handle package code, tests and current analyses without frequent environment rebuilds.
 
 # Troubleshooting
 
 ## R starts by activating `renv`
 
-Check that `CI=true` is present in the agent's task-time environment, not only exported during setup.
+Check that `CI=true` is present in the agent's task-time environment, not only exported during setup. For Copilot, also check that the repository `.Rprofile` still recognises the Copilot/CI environment.
 
 ## `simcyto` is installed but appears stale
 
@@ -249,19 +324,21 @@ For another environment, run:
 pak::pkg_install("SATVILab/simcyto", upgrade = TRUE, ask = FALSE)
 ```
 
+For Copilot, inspect `.github/workflows/copilot-setup-steps.yml` and confirm that `SATVILab/simcyto` is unpinned. A newly provisioned Copilot environment should then install the current default branch.
+
 ## A Bioconductor package fails during installation
 
-The setup scripts deliberately continue through a repair cycle rather than treating the first pak failure as final. If the final validation still fails, inspect the missing package and its Linux system requirements before changing the package code.
+The Codex and Jules setup scripts deliberately continue through a repair cycle rather than treating the first pak failure as final. If the final validation still fails, inspect the missing package and its Linux system requirements before changing the package code. For Copilot, diagnose the `setup-r-dependencies` job and system-library step in the setup workflow.
 
 ## StimGate installs but analysis tests fail
 
-Remember that the analysis code has dependencies beyond the installed package `DESCRIPTION`, including `simcyto` and the comparison tooling. Use the full agent setup when the task involves `analysis/` or `scripts/r/`.
+Remember that the analysis code has dependencies beyond the installed package `DESCRIPTION`, including `simcyto` and the comparison tooling. Use the full Codex/Jules setup when the task involves `analysis/` or `scripts/r/`. For Copilot, add a missing analysis dependency to its workflow only when Copilot is expected to execute that analysis path.
 
 # Adding another coding agent
 
 When adding another remote coding agent, prefer this pattern:
 
-1. add a small agent-specific script under `scripts/agents/`;
+1. add a small agent-specific script under `scripts/agents/`, or use the platform's repository-native workflow if it has one;
 2. reuse the same R/Bioconductor and package strategy unless the platform supplies a better native equivalent;
 3. keep `AGENTS.md` as the coding-agent source of truth for repository conventions;
 4. add the new platform to this guide; and

--- a/vignettes/coding-agents.Rmd
+++ b/vignettes/coding-agents.Rmd
@@ -1,0 +1,268 @@
+---
+title: "Setting up coding agents for StimGate"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Setting up coding agents for StimGate}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+# Overview
+
+StimGate can be developed with remote coding agents as long as the agent environment contains the same core R, Bioconductor, system and analysis dependencies used by the repository.
+
+This guide currently covers:
+
+- Google Jules
+- OpenAI Codex Cloud
+
+The repository-level instructions for coding agents live in `AGENTS.md`. Agents should read that file before changing code. The environment scripts described below are kept under `scripts/agents/` so that the setup is version-controlled alongside the package rather than copied independently between agent products.
+
+The recommended cloud-agent environment is deliberately different from ordinary local development. In local development, StimGate may activate an `renv` profile through `.Rprofile`. Cloud agents instead use a directly installed development library and should run with `CI=true`, which tells the repository not to activate `renv`.
+
+The current setup targets:
+
+- R 4.6
+- Bioconductor 3.23
+- the current `SATVILab/simcyto` default branch
+- Quarto
+- the StimGate `DESCRIPTION` dependencies and Suggests
+- development tools such as `devtools`, `rcmdcheck`, `roxygen2`, `styler`, `lintr`, `covr` and `pkgdown`
+- analysis dependencies used by the simulation and comparison workflows, including `future`, `furrr`, `progressr`, `reticulate` and `cytoUtils`
+
+`simcyto` is intentionally not pinned to a commit. StimGate development normally targets the latest version in `SATVILab/simcyto`, and the Codex maintenance script explicitly refreshes it.
+
+# Shared principles
+
+## Prefer repository scripts over duplicated UI scripts
+
+The recommended approach is to make the agent UI call the script from the checked-out repository. This keeps the authoritative setup in Git, makes changes reviewable, and avoids having different Jules, Codex and documentation copies drift apart.
+
+If an agent product only accepts pasted setup text, copy the current contents of the corresponding file under `scripts/agents/`.
+
+## Do not restore `renv` in the cloud-agent environment
+
+The cloud environment installs the packages it needs directly and then runs commands such as:
+
+```r
+#| eval: false
+devtools::load_all()
+devtools::test()
+```
+
+Do not run `renv::restore()` merely because the project contains `renv` files. For these cloud environments, a missing package should normally be treated as an environment-setup problem.
+
+## Keep `simcyto` current
+
+Use:
+
+```text
+SATVILab/simcyto
+```
+
+rather than a commit-pinned package specification unless a particular historical analysis explicitly requires an old API.
+
+## Validate the environment, not just the installer exit code
+
+Both setup scripts finish by checking that the important packages are actually available and that:
+
+```r
+#| eval: false
+devtools::load_all()
+```
+
+succeeds. Intermediate package-install failures may be recoverable, especially for Bioconductor dependencies, so the scripts use a pak-first, Bioconductor-repair, pak-again strategy before applying the final hard checks.
+
+# OpenAI Codex Cloud
+
+## Recommended Codex settings
+
+Create a Codex Cloud environment for the StimGate repository and use the universal container image.
+
+The preinstalled language versions in the universal image can normally be left at their defaults. Python is the only preinstalled language that is directly relevant to current StimGate analysis code; the comparison workflow calls the historical F-beta Python implementation through `reticulate`. The setup script separately installs NumPy and the R-side Python integration requirements.
+
+Add the following persistent environment variable:
+
+```text
+CI=true
+```
+
+This setting is important. The setup script itself runs in a separate shell from later agent commands, so exporting `CI=true` only inside the setup script is not sufficient. StimGate's `.Rprofile` uses `CI=true` to avoid activating `renv` in the cloud-agent session.
+
+Enable container caching. The initial R/Bioconductor installation is substantial, and caching avoids rebuilding the environment for every task.
+
+## Setup script
+
+Choose **Manual** setup and use:
+
+```bash
+bash scripts/agents/setup-codex.sh
+```
+
+The full script is stored at:
+
+```text
+scripts/agents/setup-codex.sh
+```
+
+It installs R and Bioconductor, the system libraries required by the package, the latest stable Quarto release, StimGate's development dependencies, the latest `SATVILab/simcyto`, and the additional analysis tooling used by the repository.
+
+## Maintenance script
+
+Use:
+
+```bash
+bash scripts/agents/maintenance-codex.sh
+```
+
+The maintenance script is intentionally lighter than the initial setup. It:
+
+1. installs any newly declared StimGate development dependencies;
+2. explicitly refreshes `SATVILab/simcyto` from its current default branch;
+3. ensures the repository-wide tools that are not declared in `DESCRIPTION` remain available; and
+4. checks that StimGate still loads.
+
+The full script is stored at:
+
+```text
+scripts/agents/maintenance-codex.sh
+```
+
+## Internet access
+
+Agent internet access is useful for StimGate because an agent may need to inspect current package documentation or fetch a GitHub dependency after the cached environment was created.
+
+A practical configuration is:
+
+- Agent internet access: **On**
+- Domain allowlist: **Common dependencies**, plus the domains needed for GitHub, R, Posit Package Manager and Bioconductor
+- HTTP methods: **All methods** if that is the only option that permits Git-over-HTTPS operations
+
+Useful additional domains include:
+
+```text
+github.com
+api.github.com
+codeload.github.com
+raw.githubusercontent.com
+objects.githubusercontent.com
+r-lib.github.io
+cloud.r-project.org
+cran.r-project.org
+r-project.org
+packagemanager.posit.co
+p3m.dev
+bioconductor.org
+```
+
+Keep the allowlist narrower than unrestricted internet access. The setup script itself should contain the normal software-installation endpoints, while task-time network access should be limited to domains the agent is likely to need.
+
+## After setup
+
+A normal coding task can use the current checkout directly. The standard package test sequence is documented in `AGENTS.md`, but common commands are:
+
+```bash
+Rscript -e "devtools::load_all(); devtools::test()"
+Rscript analysis/tests/run_analysis_tests.R
+```
+
+Run the analysis integration suite when changes touch `analysis/` or `scripts/r/`, rather than for every unrelated package change.
+
+# Google Jules
+
+## Setup
+
+For Jules, use the repository setup script:
+
+```bash
+bash scripts/agents/setup-jules.sh
+```
+
+The full script is stored at:
+
+```text
+scripts/agents/setup-jules.sh
+```
+
+The Jules version follows the same dependency strategy as the Codex setup, but retains the Jules checkout convention used by the working StimGate environment.
+
+It sets `CI=true` during setup so that R processes launched by the installer do not activate the project `renv` environment. If Jules provides a persistent environment-variable setting for a project, also set `CI=true` there so later agent R sessions use the same direct development library.
+
+## Network and repository access
+
+Jules needs access to the StimGate repository and to the package sources used during environment setup. If network controls are available, allow the same R, Bioconductor, Posit and GitHub domains listed for Codex rather than enabling unrelated destinations.
+
+## Keeping the environment current
+
+Jules does not currently use the Codex maintenance-script mechanism described above. When the environment is rebuilt, `setup-jules.sh` installs the latest `SATVILab/simcyto` rather than a pinned revision.
+
+If a long-lived Jules environment becomes stale, rerun the setup or explicitly refresh the GitHub package from R:
+
+```r
+#| eval: false
+pak::pkg_install("SATVILab/simcyto", upgrade = TRUE, ask = FALSE)
+```
+
+# Alternative environment strategies
+
+## Use the GitHub Actions environment as the minimal baseline
+
+The repository's GitHub Actions workflows are useful references for the minimum environment needed for package and analysis tests. They are deliberately more compact than the cloud-agent scripts. This is a good option when an agent only needs package tests and not the full range of research analyses.
+
+## Use `renv` for local or long-lived interactive development
+
+The direct cloud-agent installation is not intended to replace the project's `renv` profiles for ordinary local development. `renv` remains useful when an exact reproducible local library is more important than fast cloud-agent provisioning.
+
+## Pin dependencies only for reproducibility exercises
+
+The agent environment normally follows the current `simcyto` repository. Pinning a GitHub SHA is appropriate when reproducing a historical result or debugging a version-specific regression, but it should be an explicit task-level decision rather than the default development environment.
+
+## Reduce the environment for narrow tasks
+
+An agent working only on documentation or a small package function may not need Quarto, the comparison stack, or all analysis dependencies. A smaller environment can start faster. The full scripts are intentionally broad because the StimGate coding agents are expected to handle package code, tests and current analyses without frequent environment rebuilds.
+
+# Troubleshooting
+
+## R starts by activating `renv`
+
+Check that `CI=true` is present in the agent's task-time environment, not only exported during setup.
+
+## `simcyto` is installed but appears stale
+
+In Codex, rerun the maintenance script:
+
+```bash
+bash scripts/agents/maintenance-codex.sh
+```
+
+For another environment, run:
+
+```r
+#| eval: false
+pak::pkg_install("SATVILab/simcyto", upgrade = TRUE, ask = FALSE)
+```
+
+## A Bioconductor package fails during installation
+
+The setup scripts deliberately continue through a repair cycle rather than treating the first pak failure as final. If the final validation still fails, inspect the missing package and its Linux system requirements before changing the package code.
+
+## StimGate installs but analysis tests fail
+
+Remember that the analysis code has dependencies beyond the installed package `DESCRIPTION`, including `simcyto` and the comparison tooling. Use the full agent setup when the task involves `analysis/` or `scripts/r/`.
+
+# Adding another coding agent
+
+When adding another remote coding agent, prefer this pattern:
+
+1. add a small agent-specific script under `scripts/agents/`;
+2. reuse the same R/Bioconductor and package strategy unless the platform supplies a better native equivalent;
+3. keep `AGENTS.md` as the coding-agent source of truth for repository conventions;
+4. add the new platform to this guide; and
+5. avoid copying version-pinned dependency lists into several unrelated configuration files unless reproducibility requires it.


### PR DESCRIPTION
Adds a developer-facing pkgdown/vignette guide for setting up remote coding agents for StimGate.

Includes:
- Codex Cloud configuration guidance
- Codex setup and maintenance scripts
- Jules setup guidance and script
- GitHub Copilot coding-agent setup guidance
- persistent `CI=true` guidance to avoid cloud-agent `renv` activation
- current unpinned `SATVILab/simcyto` installation/refresh behaviour across Codex, Jules, Copilot and analysis CI
- removal of the existing `simcyto` SHA pins from `.github/workflows/copilot-setup-steps.yml` and `.github/workflows/analysis-integration.yaml`
- network allowlist and caching guidance
- troubleshooting and alternative environment strategies

The environment scripts are version-controlled under `scripts/agents/`, while Copilot uses its repository-native `.github/workflows/copilot-setup-steps.yml` configuration.