### PR TITLE
Fix cloud-agent CRAN binary repository

### DIFF
--- a/scripts/agents/maintenance-codex.sh
+++ b/scripts/agents/maintenance-codex.sh
@@ -11,9 +11,12 @@ if [ "${CI:-}" != "true" ]; then
     exit 1
 fi
 
-R_MINOR="4.6"
 BIOC_VERSION="3.23"
-POSIT_CRAN="https://packagemanager.posit.co/cran/latest/bin/linux/noble-x86_64/${R_MINOR}"
+
+# Keep this in sync with setup-codex.sh. pak recognises the __linux__ form as
+# a Linux binary repository; the newer /bin/linux/... form may be treated as
+# source and trigger unnecessary source builds.
+POSIT_CRAN="https://packagemanager.posit.co/cran/__linux__/noble/latest"
 
 cat > /tmp/stimgate-agent-repos.R <<EOF
 options(

--- a/scripts/agents/setup-codex.sh
+++ b/scripts/agents/setup-codex.sh
@@ -13,7 +13,11 @@ fi
 
 R_MINOR="4.6"
 BIOC_VERSION="3.23"
-POSIT_CRAN="https://packagemanager.posit.co/cran/latest/bin/linux/noble-x86_64/${R_MINOR}"
+
+# Use Posit Package Manager's pak-compatible Linux binary URL. Do not replace
+# this with the newer /bin/linux/noble-x86_64/<R> form: pak currently
+# classifies that repository as source and rebuilds ordinary CRAN packages.
+POSIT_CRAN="https://packagemanager.posit.co/cran/__linux__/noble/latest"
 
 sudo apt-get update -qq
 sudo apt-get install --no-install-recommends -y \
@@ -65,6 +69,12 @@ options(
     }
 )
 EOF
+
+sudo env CI=true Rscript --vanilla -e '
+source("/tmp/stimgate-agent-repos.R")
+cat("pak repository status:\n")
+print(pak::repo_status())
+'
 
 # Install the latest stable Quarto release. Avoid pinning the cloud environment
 # to an obsolete Quarto release while still using a deterministic release asset.

--- a/scripts/agents/setup-jules.sh
+++ b/scripts/agents/setup-jules.sh
@@ -10,7 +10,11 @@ export PKG_SYSREQS_VERBOSE=true
 
 R_MINOR="4.6"
 BIOC_VERSION="3.23"
-POSIT_CRAN="https://packagemanager.posit.co/cran/latest/bin/linux/noble-x86_64/${R_MINOR}"
+
+# Use Posit Package Manager's pak-compatible Linux binary URL. Do not replace
+# this with the newer /bin/linux/noble-x86_64/<R> form: pak currently
+# classifies that repository as source and rebuilds ordinary CRAN packages.
+POSIT_CRAN="https://packagemanager.posit.co/cran/__linux__/noble/latest"
 
 sudo apt-get update -qq
 sudo apt-get install --no-install-recommends -y \

--- a/vignettes/coding-agents.Rmd
+++ b/vignettes/coding-agents.Rmd
@@ -62,6 +62,16 @@ devtools::test()
 
 Do not run `renv::restore()` merely because the project contains `renv` files. For these cloud environments, a missing package should normally be treated as an environment-setup problem.
 
+## Use Posit Linux binaries in a form pak recognises
+
+The Codex and Jules scripts use:
+
+```text
+https://packagemanager.posit.co/cran/__linux__/noble/latest
+```
+
+for ordinary CRAN packages. Keep this `__linux__` form unless pak adds equivalent support for the newer Posit `/bin/linux/...` repository layout. In testing, pak classified the newer URL as a source repository and attempted to rebuild more than 100 ordinary CRAN dependencies from source. The `__linux__` URL lets pak use prebuilt Linux binaries where available, which makes initial cloud setup substantially faster and less fragile.
+
 ## Keep `simcyto` current
 
 Use:
@@ -308,6 +318,16 @@ An agent working only on documentation or a small package function may not need 
 ## R starts by activating `renv`
 
 Check that `CI=true` is present in the agent's task-time environment, not only exported during setup. For Copilot, also check that the repository `.Rprofile` still recognises the Copilot/CI environment.
+
+## pak starts building large numbers of ordinary CRAN packages
+
+Check the repository URL printed by `pak::repo_status()`. For Codex/Jules, CRAN should use:
+
+```text
+https://packagemanager.posit.co/cran/__linux__/noble/latest
+```
+
+If pak reports CRAN as a source repository and starts compiling ordinary packages such as `jsonlite`, `callr`, `otel`, `rlang` or `ggplot2`, check that the newer `/bin/linux/...` Posit URL has not been substituted into the agent script.
 
 ## `simcyto` is installed but appears stale
 


### PR DESCRIPTION
Follow-up to merged PR #332.

The first Codex environment build showed that pak classified the newer Posit Package Manager URL (`/cran/latest/bin/linux/noble-x86_64/4.6`) as a source repository, causing ordinary CRAN packages to be rebuilt from source and eventually stalling during the dependency build.

This PR:
- switches Codex setup, Codex maintenance, and Jules setup to the pak-compatible Posit Linux binary URL `https://packagemanager.posit.co/cran/__linux__/noble/latest`;
- adds a `pak::repo_status()` diagnostic during Codex setup;
- documents why the newer URL should not be substituted while pak has this behaviour;
- updates the coding-agent website guide with the troubleshooting note.

`SATVILab/simcyto` remains deliberately unpinned and continues to track the latest default-branch version.