### PR TITLE
Validate canonical analysis 7 cache provenance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,6 +408,8 @@ QMD runtime or unrelated plotting/orchestration code.
    - For external chunking, all chunks of one logical run must use the same run ID and write under the same staged run directory, separated by chunk labels.
    - Never promote on partial/incomplete runs. Promote only after required chunks are complete and collated outputs validate.
    - Promotion updates `current/` only after a complete staged run is available; failed/interrupted staged runs remain inspectable and resumable.
+   - Read canonical outputs through `.analysis_current_file()`, which requires a `COMPLETE` marker, a readable manifest for the requested analysis key, and any analysis-specific semantic version required by the caller.
+   - Record scientific and semantic settings in the run manifest. Reusing an explicit run ID must match those settings; only operational controls such as plotting, simulation execution and the current chunk index may differ across invocations.
 
 ---
 

--- a/analysis/7-sim-compare-freq_bs.qmd
+++ b/analysis/7-sim-compare-freq_bs.qmd
@@ -583,16 +583,14 @@ if (isTRUE(run_simulations)) {
 ```{r}
 #| label: compare-collate
 #| error: true
-if (!exists("compare_raw") || nrow(compare_raw) == 0L) {
-  path_rds <- file.path(run_ctx$current_dir, "collated", "compare_raw.rds")
-  if (file.exists(path_rds)) {
-    compare_raw <- readRDS(path_rds)
-  }
-}
-
-if (!exists("compare_raw") || nrow(compare_raw) == 0L) {
-  stop("Could not find canonical compare_raw.rds in current/. Run the simulation chunk first.")
-}
+path_rds <- .analysis_current_file(
+  run_ctx = run_ctx,
+  relative_path = c("collated", "compare_raw.rds"),
+  required_params = list(
+    comparison_semantics_version = comparison_semantics_version
+  )
+)
+compare_raw <- readRDS(path_rds)
 
 compare_tbl <- compare_raw
 

--- a/analysis/tests/testthat/test-analysis-7-transactional-multichunk.R
+++ b/analysis/tests/testthat/test-analysis-7-transactional-multichunk.R
@@ -30,6 +30,12 @@ test_that("analysis 7 uses run-specific progress and validates full nested colla
     content,
     fixed = TRUE
   ))
+  expect_true(grepl(".analysis_current_file", content, fixed = TRUE))
+  expect_true(grepl(
+    "required_params = list(",
+    content,
+    fixed = TRUE
+  ))
   expect_true(grepl(
     "set.seed(as.integer(row$sim_seed[[1]]))",
     content,

--- a/analysis/tests/testthat/test-analysis-runtime.R
+++ b/analysis/tests/testthat/test-analysis-runtime.R
@@ -262,6 +262,111 @@ test_that("explicit run ID reuse rejects incompatible manifest settings", {
   )
 })
 
+test_that("explicit run ID reuse checks scientific but not operational parameters", {
+  env <- .load_runtime_env()
+
+  tmp_project <- withr::local_tempdir()
+  withr::local_dir(tmp_project)
+  writeLines(c("directories:", "  docs:", "    path: docs"), "_projr.yml")
+
+  env$.analysis_run_context(
+    analysis_key = c("sim", "analysis-runtime-scientific-params"),
+    run_id = "shared-scientific-run",
+    params = list(
+      run_simulations = TRUE,
+      run_plots = FALSE,
+      sim_grid_chunk_index = 1L,
+      sim_grid_n_chunks = 2L,
+      comparison_semantics_version = "corrected-v1"
+    ),
+    sim_grid_chunk_index = 1L,
+    sim_grid_n_chunks = 2L
+  )
+
+  expect_no_error(env$.analysis_run_context(
+    analysis_key = c("sim", "analysis-runtime-scientific-params"),
+    run_id = "shared-scientific-run",
+    params = list(
+      run_simulations = FALSE,
+      run_plots = TRUE,
+      sim_grid_chunk_index = 2L,
+      sim_grid_n_chunks = 2L,
+      comparison_semantics_version = "corrected-v1"
+    ),
+    sim_grid_chunk_index = 2L,
+    sim_grid_n_chunks = 2L
+  ))
+
+  expect_error(
+    env$.analysis_run_context(
+      analysis_key = c("sim", "analysis-runtime-scientific-params"),
+      run_id = "shared-scientific-run",
+      params = list(
+        run_simulations = TRUE,
+        run_plots = FALSE,
+        sim_grid_chunk_index = 2L,
+        sim_grid_n_chunks = 2L,
+        comparison_semantics_version = "corrected-v2"
+      ),
+      sim_grid_chunk_index = 2L,
+      sim_grid_n_chunks = 2L
+    ),
+    "incompatible with existing manifest"
+  )
+})
+
+test_that("canonical current reads require completion and compatible provenance", {
+  env <- .load_runtime_env()
+
+  tmp_project <- withr::local_tempdir()
+  withr::local_dir(tmp_project)
+  writeLines(c("directories:", "  docs:", "    path: docs"), "_projr.yml")
+
+  ctx <- env$.analysis_run_context(
+    analysis_key = c("sim", "analysis-runtime-current"),
+    run_id = "current-run",
+    params = list(comparison_semantics_version = "corrected-v1")
+  )
+  path_staged <- file.path(ctx$staging_collated_dir, "result.rds")
+  env$.write_rds_atomic(tibble::tibble(x = 1L), path_staged)
+
+  expect_error(
+    env$.analysis_current_file(
+      ctx,
+      c("collated", "result.rds"),
+      list(comparison_semantics_version = "corrected-v1")
+    ),
+    "No complete canonical current result"
+  )
+
+  env$.analysis_mark_chunk(
+    run_ctx = ctx,
+    total_sims = 1L,
+    completed_sims = 1L,
+    failed_sims = 0L,
+    collate_ok = TRUE,
+    validation_ok = TRUE
+  )
+  expect_true(isTRUE(env$.analysis_promote_run(ctx)))
+
+  expect_identical(
+    env$.analysis_current_file(
+      ctx,
+      c("collated", "result.rds"),
+      list(comparison_semantics_version = "corrected-v1")
+    ),
+    file.path(ctx$current_dir, "collated", "result.rds")
+  )
+  expect_error(
+    env$.analysis_current_file(
+      ctx,
+      c("collated", "result.rds"),
+      list(comparison_semantics_version = "legacy-v0")
+    ),
+    "comparison_semantics_version"
+  )
+})
+
 test_that("concurrent chunk updates preserve per-chunk status and aggregate counts", {
   env <- .load_runtime_env()
 

--- a/analysis/tests/testthat/test-sim-compare-freq_bs-simcyto.R
+++ b/analysis/tests/testthat/test-sim-compare-freq_bs-simcyto.R
@@ -441,10 +441,14 @@ test_that(
     expect_true(grepl("\\.analysis_mark_chunk", content))
     expect_true(grepl("\\.analysis_promote_run", content))
 
-    # Reads canonical current/collated/compare_raw.rds
+    # Reads only a complete canonical current result with corrected semantics
     # and does NOT write/read fixed legacy compare_list_raw.rds
     expect_true(grepl(
-      'file\\.path\\(run_ctx\\$current_dir,\\s*"collated",\\s*"compare_raw\\.rds"\\)',
+      "\\.analysis_current_file",
+      content
+    ))
+    expect_true(grepl(
+      "required_params\\s*=\\s*list\\(\\s*comparison_semantics_version",
       content
     ))
     expect_false(grepl("compare_list_raw\\.rds", content))

--- a/scripts/r/analysis-runtime.R
+++ b/scripts/r/analysis-runtime.R
@@ -128,10 +128,12 @@
     return(list())
   }
 
-  keep <- intersect(
-    names(params),
-    c("sim_grid_n_chunks", "sim_grid_shuffle_seed")
+  operational_params <- c(
+    "run_simulations",
+    "run_plots",
+    "sim_grid_chunk_index"
   )
+  keep <- sort(setdiff(names(params), operational_params))
   params[keep]
 }
 
@@ -196,6 +198,87 @@
     return(NULL)
   }
   tryCatch(readRDS(path), error = function(e) NULL)
+}
+
+.analysis_current_file <- function(
+    run_ctx,
+    relative_path,
+    required_params = list()) {
+  if (
+    length(relative_path) == 0L ||
+      any(is.na(relative_path)) ||
+      any(!nzchar(as.character(relative_path)))
+  ) {
+    stop("relative_path must contain at least one non-empty path component.")
+  }
+  if (
+    length(required_params) > 0L &&
+      (is.null(names(required_params)) || any(!nzchar(names(required_params))))
+  ) {
+    stop("required_params must be a fully named list.")
+  }
+
+  complete_path <- file.path(run_ctx$current_dir, "COMPLETE")
+  if (!file.exists(complete_path)) {
+    stop(
+      "No complete canonical current result is available for analysis key: ",
+      paste(run_ctx$analysis_key, collapse = "/"),
+      "."
+    )
+  }
+
+  manifest_path <- file.path(run_ctx$current_dir, "manifest.rds")
+  manifest <- .analysis_read_manifest(manifest_path)
+  if (is.null(manifest)) {
+    stop("Canonical current result has no readable manifest.rds.")
+  }
+
+  if (!identical(
+    as.character(manifest$analysis_key),
+    as.character(run_ctx$analysis_key)
+  )) {
+    stop("Canonical current manifest does not match the requested analysis key.")
+  }
+
+  if (length(required_params) > 0L) {
+    manifest_params <- manifest$params
+    mismatched_params <- names(required_params)[vapply(
+      names(required_params),
+      function(nm) {
+        is.null(manifest_params) ||
+          !nm %in% names(manifest_params) ||
+          !isTRUE(all.equal(
+            manifest_params[[nm]],
+            required_params[[nm]],
+            check.attributes = FALSE
+          ))
+      },
+      logical(1)
+    )]
+
+    if (length(mismatched_params) > 0L) {
+      stop(
+        "Canonical current result is incompatible with the required manifest ",
+        "parameters: ",
+        paste(mismatched_params, collapse = ", "),
+        ". Rerun the analysis before using these results."
+      )
+    }
+  }
+
+  path <- do.call(
+    file.path,
+    c(list(run_ctx$current_dir), as.list(as.character(relative_path)))
+  )
+  if (!file.exists(path)) {
+    stop(
+      "Canonical current result is complete but the required file is missing: ",
+      paste(as.character(relative_path), collapse = "/"),
+      "."
+    )
+  }
+
+  path
 }
 
 .analysis_find_existing_run_manifest <- function(staging_root, run_id) {


### PR DESCRIPTION
Closes #338.

Part of #341.

## Summary

- require analysis 7 collation to read a complete canonical `current/` result
- validate the canonical manifest's comparison-semantics version before reading results
- reject explicit run-ID reuse when scientific or semantic settings differ, while allowing operational controls to vary across chunks
- add integration coverage for incomplete, compatible and stale canonical results

## Validation

- `git diff --check`
- Full analysis integration tests will run in GitHub Actions because R is not available in the local work environment.