### PR TITLE
Fix prejoin gate propagation

### DIFF
--- a/R/cp_uns_loc.R
+++ b/R/cp_uns_loc.R
@@ -231,6 +231,7 @@
 #' @keywords internal
 .prepareDataForPrejoinInd <- function(exList) {
   indUns <- names(exList)[1]
+  indStim <- names(exList)[-1]
   exTblStim <- exList[seq.int(2, length(exList))] |>
     dplyr::bind_rows()
   exTblStim <- exTblStim[order(.getCut(exTblStim)), ]
@@ -238,7 +239,7 @@
     exList[[1]],
     exTblStim
   ) |>
-    stats::setNames(c(indUns, names(exList)[seq(2, length(exList))]))
+    stats::setNames(c(indUns, .createCombinedIdentifier(indStim)))
 }
 
 #' @keywords internal
@@ -251,6 +252,7 @@
     pathProject,
     stage) {
   .debug("prejoin") # nolint
+  indStim <- names(exListNoMin)[-1]
 
   # get marker expression for stim samples,
   # join and then sort into descending order
@@ -260,16 +262,22 @@
   )
 
   # get cutpoints for gate combn method for a range of fdr's
-  .getCpUnsLocSample(
+  cpUnsPrejoin <- .getCpUnsLocSample(
     exListOrig = exListPrejoin[["exListOrig"]],
-    exListNoMinStim = exListPrejoin[["exListNoMin"]],
+    exListNoMinStim = exListPrejoin[["exListNoMin"]][-1],
     exTblUnsBias = exTblUnsBias,
     chnlSettings = chnlSettings,
     bias = bias,
     stage = stage,
-    pathProject = pathProject
-  ) |>
-    purrr::map(function(x) list("prejoin" = x))
+    pathProject = pathProject,
+    indStim = indStim,
+    exListOrigOutput = exListOrig,
+    prejoin = TRUE
+  )
+  list(
+    "cp" = list("prejoin" = cpUnsPrejoin[["loc"]]),
+    "pList" = list()
+  )
 }
 
 # --------------------------------
@@ -458,9 +466,14 @@
     chnlSettings,
     bias,
     pathProject,
-    stage) {
+    stage,
+    indStim = NULL,
+    exListOrigOutput = NULL,
+    prejoin = FALSE) {
   .debug("getting loc gate at sample level") # nolint
   force(pathProject)
+  indStim <- indStim %||% names(exListNoMinStim)
+  exListOrigOutput <- exListOrigOutput %||% exListOrig
 
   # get cutpoints for each sample
   cpUnsLocObjList <- purrr::map(
@@ -533,11 +546,12 @@
   .getCpUnsLocOutput(
     cpUnsLocObjList = cpUnsLocObjList,
     indUns = names(exListOrig)[1],
-    indStim = names(exListNoMinStim),
+    indStim = indStim,
     stage = stage,
     pathProject = .pathProject,
     chnl = chnl,
-    exListOrig = exListOrig
+    exListOrig = exListOrigOutput,
+    prejoin = prejoin
   )
 }
 

--- a/R/cp_uns_loc_output.R
+++ b/R/cp_uns_loc_output.R
@@ -257,7 +257,8 @@
     stage,
     pathProject,
     chnl,
-    exListOrig) {
+    exListOrig,
+    prejoin = FALSE) {
   stageChnl <- file.path(stage, chnl)
   cpVec <- .getCpUnsLocSampleCpRep(
     stage = stage,
@@ -265,7 +266,8 @@
     indUns = indUns,
     indStim = indStim,
     pathProject = pathProject,
-    chnl = chnl
+    chnl = chnl,
+    prejoin = prejoin
   )
   indCombined <- .createCombinedIdentifier(indStim)
   .intSave(indCombined, stageChnl, pathProject, cpVec)
@@ -306,7 +308,8 @@
     indUns,
     indStim,
     pathProject,
-    chnl) {
+    chnl,
+    prejoin = FALSE) {
   .debug("Possibly re-using calculated cutpoints") # nolint
   indCombined <- .createCombinedIdentifier(indStim)
   stageChnl <- file.path(stage, chnl)
@@ -331,7 +334,10 @@
     pathProject
   )
 
-  if (length(cpVec) != length(indStim)) {
+  if (isTRUE(prejoin) && length(cpVec) != 1L) {
+    stop("Prejoin must produce exactly one cutpoint per batch")
+  }
+  if (isTRUE(prejoin) || length(cpVec) != length(indStim)) {
     .intSaveNm(
       "prejoinedCpUsed",
       NULL,
@@ -473,5 +479,8 @@
     source,
     metaOut$locSource
   )
+  if (identical(source, "prejoin")) {
+    metaOut$locGeneratedDirect[metaOut$locGenerated %in% TRUE] <- FALSE
+  }
   metaOut
 }

--- a/tests/testthat/test-coverage-gaps.R
+++ b/tests/testthat/test-coverage-gaps.R
@@ -47,12 +47,59 @@ test_that("interpFunctionWorksWhenXLowEqualVal", {
   expect_equal(result, 10)
 })
 
-# Note: prejoin gate combination test is skipped due to a bug in the current implementation
-# that causes: "object 'countStim' not found" error. This may need investigation in the main codebase.
 test_that("stimgateGateRunsWithGateCombnPrejoin", {
-  skip(
-    "prejoin gate combination has a bug causing 'object countStim not found' error"
+  skip_if_not_installed("flowWorkspace")
+  skip_if_not_installed("flowCore")
+
+  exampleData <- getExampleData()
+  gs <- flowWorkspace::load_gs(exampleData$pathGs)
+  batchList <- list(batch1 = c(1, 2, 4))
+  stimInd <- as.character(batchList[[1]][-1])
+  pathProject <- tempfile("testPrejoin")
+  withr::defer(unlink(pathProject, recursive = TRUE))
+  withr::local_envvar(STIMGATE_INTERMEDIATE = "all")
+
+  result <- gateStim(
+    .data = gs,
+    pathProject = pathProject,
+    popGate = "root",
+    batchList = batchList,
+    marker = exampleData$marker,
+    gateCombn = "prejoin"
   )
+
+  expect_identical(result, pathProject)
+  expect_identical(stimgateMetaReadBatchList(pathProject), batchList)
+
+  gateTbl <- getStimGates(pathProject)
+  stimGateTbl <- gateTbl[gateTbl$ind %in% stimInd, ]
+  expect_gt(nrow(stimGateTbl), 0L)
+  expect_true(all(grepl("prejoin", stimGateTbl$gateName, fixed = TRUE)))
+
+  gateGroups <- split(
+    stimGateTbl,
+    interaction(stimGateTbl$gateName, stimGateTbl$chnl, drop = TRUE)
+  )
+  expect_true(all(vapply(gateGroups, function(x) {
+    setequal(x$ind, stimInd) && length(unique(x$gate)) == 1L
+  }, logical(1))))
+
+  detailTbl <- getStimGatesDetailed(pathProject)
+  stimDetailTbl <- detailTbl[
+    detailTbl$detailLevel == "sample" & detailTbl$ind %in% stimInd,
+  ]
+  expect_gt(nrow(stimDetailTbl), 0L)
+  detailGroups <- split(stimDetailTbl, stimDetailTbl$chnl)
+  expect_true(all(vapply(detailGroups, function(x) {
+    setequal(x$ind, stimInd) && length(unique(x$threshold)) == 1L
+  }, logical(1))))
+  expect_true(all(stimDetailTbl$locGenerated))
+  expect_false(any(stimDetailTbl$locGeneratedDirect))
+  expect_true(all(stimDetailTbl$locSource == "prejoin"))
+  expect_true(all(
+    stimDetailTbl$thresholdOrigin ==
+      "prejoin_generated_from_joined_stim_conditions"
+  ))
 })
 
 test_that("stimgateGateRunsWithGateCombnNo", {


### PR DESCRIPTION
Fixes #3.

The prejoin path was passing the unstimulated entry and all stimulated identifiers to sample-level gating even though preparation produced one joined stimulated table. This change gates only the joined table, expands its single cutpoint back to every original stimulated sample, and preserves generated, non-direct prejoin provenance. Non-prejoin defaults are unchanged.

Tests:
- `devtools::test(filter = "coverage-gaps", stop_on_failure = TRUE)` (34 passed)
- `devtools::test(filter = "cp_uns_loc_threshold", stop_on_failure = TRUE)` (71 passed)
- `devtools::test(stop_on_failure = TRUE)` (679 passed, 0 failed, 2 warnings, 2 skips)
- `devtools::check()` against a clean tracked-file source copy (0 errors, 0 warnings, 2 unrelated NOTEs)