### PR TITLE
Enforce explicit gateCombn min and verify multi-condition combination (#346)

### DIFF
--- a/R/cp_uns_loc.R
+++ b/R/cp_uns_loc.R
@@ -382,10 +382,12 @@
       metaOut <- meta
       stimRow <- !(metaOut$locSource %in% "unstim_summary")
       metaOut$locGenerated[stimRow] <- TRUE
-      metaOut$locGeneratedDirect[stimRow] <- meta$locGeneratedDirect[
-        stimRow
-      ] %in%
-        TRUE
+      stimDirectMatches <- (meta$locGeneratedDirect %in% TRUE) &
+        (abs(
+          suppressWarnings(as.numeric(cp)) -
+            suppressWarnings(as.numeric(cpCombined))
+        ) < 1e-7)
+      metaOut$locGeneratedDirect[stimRow] <- stimDirectMatches[stimRow]
       metaOut$locSource[stimRow & !(metaOut$locGeneratedDirect %in% TRUE)] <-
         "combined"
       metaOut$locReason[stimRow & !(metaOut$locGeneratedDirect %in% TRUE)] <-

--- a/analysis/7-sim-compare-freq_bs.qmd
+++ b/analysis/7-sim-compare-freq_bs.qmd
@@ -181,6 +181,7 @@ stimgate_bw_ncell_max <- 1e4
 stimgate_bw_fallback <- "auto"
 stimgate_bw_min <- "none"
 stimgate_bw_max <- "none"
+stimgate_gate_combn <- "min"
 
 # StimGate method settings for the full method comparison.
 # Cluster refinement is enabled to represent the full one-marker procedure.
@@ -218,6 +219,7 @@ sim_grid <- tidyr::expand_grid(
   bw_fallback = stimgate_bw_fallback,
   bw_min = stimgate_bw_min,
   bw_max = stimgate_bw_max,
+  gate_combn = stimgate_gate_combn,
   sample_perturbation_sd = sample_perturbation_sd_vec,
   condition_perturbation_sd = condition_perturbation_sd_vec,
   cluster_perturbation_sd = cluster_perturbation_sd_vec,
@@ -242,6 +244,7 @@ sim_grid <- tidyr::expand_grid(
     bw_fallback,
     bw_min,
     bw_max,
+    gate_combn,
     bias_uns,
     sample_perturbation_sd,
     condition_perturbation_sd,
@@ -416,6 +419,7 @@ run_ctx <- .analysis_run_context(
     stimgate_bw_fallback = stimgate_bw_fallback,
     stimgate_bw_min = stimgate_bw_min,
     stimgate_bw_max = stimgate_bw_max,
+    stimgate_gate_combn = stimgate_gate_combn,
     tol_clust = tol_clust,
     loc_enforce_shape_threshold = loc_enforce_shape_threshold,
     calc_cyt_pos_gates = calc_cyt_pos_gates,
@@ -467,6 +471,7 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
     tolClust = tol_clust,
     locEnforceShapeThreshold = loc_enforce_shape_threshold,
     calcCytPosGates = calc_cyt_pos_gates,
+    gateCombn = stimgate_gate_combn,
     pathFbeta = path_fbeta,
     fbetaBeta = fbeta_beta,
     fbetaTheta = fbeta_theta,

--- a/analysis/8-sim-compare-freq_bs-batch.qmd
+++ b/analysis/8-sim-compare-freq_bs-batch.qmd
@@ -343,6 +343,7 @@ if (isTRUE(run_simulations) && nrow(sim_grid) > 0L) {
     tolClust = tol_clust,
     locEnforceShapeThreshold = loc_enforce_shape_threshold,
     calcCytPosGates = calc_cyt_pos_gates,
+    gateCombn = "min",
     pathFbeta = path_fbeta,
     fbetaBeta = fbeta_beta,
     fbetaTheta = fbeta_theta,

--- a/analysis/tests/testthat/test-wrapper-api.R
+++ b/analysis/tests/testthat/test-wrapper-api.R
@@ -108,3 +108,15 @@ test_that(".simCompareFreqBs forwards to gateStim via .simCompareStimgateRows wi
   expect_false(any(stimgate_res[["method"]] == "stimgate_error"))
   expect_true(all(is.na(stimgate_res[["error"]])))
 })
+
+test_that(
+  ".simCompareFreqBs and .simCompareStimgateRows accept and forward gateCombn",
+  {
+    env <- .load_analysis_env()
+
+    expect_true("gateCombn" %in% names(formals(env$.simCompareStimgateRows)))
+    expect_true("gateCombn" %in% names(formals(env$.simCompareFreqBs)))
+    expect_equal(formals(env$.simCompareStimgateRows)$gateCombn, "min")
+    expect_equal(formals(env$.simCompareFreqBs)$gateCombn, "min")
+  }
+)

--- a/scripts/r/sim-compare-freq_bs.R
+++ b/scripts/r/sim-compare-freq_bs.R
@@ -1599,6 +1599,12 @@
     if ("bias_uns" %in% names(row)) {
       paste0("bias = ", row$bias_uns[[1]])
     },
+    if ("gate_combn" %in% names(row)) {
+      paste0("gate_combn = ", row$gate_combn[[1]])
+    },
+    if ("gateCombn" %in% names(row)) {
+      paste0("gate_combn = ", row$gateCombn[[1]])
+    },
     if ("mismatch_type" %in% names(row)) {
       paste0("mismatch_type = ", row$mismatch_type[[1]])
     },
@@ -1897,6 +1903,13 @@
         calcCytPosGates = calcCytPosGates,
         includeLocCondition = includeLocCondition,
         includeLocDetails = includeLocDetails,
+        gateCombn = if ("gate_combn" %in% names(row)) {
+          row$gate_combn[[1]]
+        } else if ("gateCombn" %in% names(row)) {
+          row$gateCombn[[1]]
+        } else {
+          "min"
+        },
         stimMeanShift = stimMeanShiftVal,
         stimSdMultiplier = stimSdMultVal,
         stimMeanShiftClusters = stimMeanShiftClustersVal,

--- a/tests/testthat/test-cp_uns_loc_threshold.R
+++ b/tests/testthat/test-cp_uns_loc_threshold.R
@@ -304,6 +304,80 @@ test_that(".getCpUnsLocCombineCpWithMeta propagates combined metadata", {
   )
 })
 
+test_that(".getCpUnsLocCombineCpWithMeta uses min of generated thresholds and ignores fallback cutpoints", {
+  # Multi-condition batch:
+  # stim1 generated 3.5, stim2 generated 2.8, stim3 is fallback at 0.5 (lower than 2.8), uns is 3.15
+  cp_vec <- c("stim1" = 3.5, "stim2" = 2.8, "stim3" = 0.5, "uns" = 3.15)
+  attr(cp_vec, "locGenerated") <- c(TRUE, TRUE, FALSE, TRUE)
+  attr(cp_vec, "locGeneratedDirect") <- c(TRUE, TRUE, FALSE, FALSE)
+  attr(cp_vec, "locSource") <- c("direct", "direct", "not_calculated", "unstim_summary")
+  attr(cp_vec, "locReason") <- c("detected", "detected", "fallback_above_range", "mean")
+
+  combined_out <- .getCpUnsLocCombineCpWithMeta(cp_vec, gateCombn = "min")
+  cp_min <- combined_out[["min"]]
+
+  # All conditions receive min of generated thresholds (2.8), ignoring fallback (0.5)
+  expect_equal(as.numeric(cp_min["stim1"]), 2.8)
+  expect_equal(as.numeric(cp_min["stim2"]), 2.8)
+  expect_equal(as.numeric(cp_min["stim3"]), 2.8)
+  expect_equal(as.numeric(cp_min["uns"]), 2.8)
+
+  meta_comb <- .getCpUnsLocMetaFromCp(cp_min)
+
+  # stim2 matches the minimum and remains direct
+  expect_true(meta_comb$locGenerated[meta_comb$ind == "stim2"])
+  expect_true(meta_comb$locGeneratedDirect[meta_comb$ind == "stim2"])
+  expect_equal(meta_comb$locSource[meta_comb$ind == "stim2"], "direct")
+
+  # stim1 was lowered from 3.5 to 2.8 -> combined
+  expect_true(meta_comb$locGenerated[meta_comb$ind == "stim1"])
+  expect_false(meta_comb$locGeneratedDirect[meta_comb$ind == "stim1"])
+  expect_equal(meta_comb$locSource[meta_comb$ind == "stim1"], "combined")
+  expect_equal(
+    meta_comb$locReason[meta_comb$ind == "stim1"],
+    "combined_from_generated_local_fdr_thresholds"
+  )
+
+  # stim3 was non-generated fallback -> combined
+  expect_true(meta_comb$locGenerated[meta_comb$ind == "stim3"])
+  expect_false(meta_comb$locGeneratedDirect[meta_comb$ind == "stim3"])
+  expect_equal(meta_comb$locSource[meta_comb$ind == "stim3"], "combined")
+  expect_equal(
+    meta_comb$locReason[meta_comb$ind == "stim3"],
+    "combined_from_generated_local_fdr_thresholds"
+  )
+
+  # uns receives unstim_summary
+  expect_true(meta_comb$locGenerated[meta_comb$ind == "uns"])
+  expect_false(meta_comb$locGeneratedDirect[meta_comb$ind == "uns"])
+  expect_equal(meta_comb$locSource[meta_comb$ind == "uns"], "unstim_summary")
+  expect_equal(
+    meta_comb$locReason[meta_comb$ind == "uns"],
+    "summary_of_combined_generated_local_fdr_thresholds"
+  )
+})
+
+test_that(".getCpUnsLocCombineCpWithMeta handles all-fallback conditions cleanly under min", {
+  cp_vec <- c("stim1" = 5.0, "stim2" = 6.0, "uns" = NA_real_)
+  attr(cp_vec, "locGenerated") <- c(FALSE, FALSE, FALSE)
+  attr(cp_vec, "locGeneratedDirect") <- c(FALSE, FALSE, FALSE)
+  attr(cp_vec, "locSource") <- c("not_calculated", "not_calculated", "unstim_summary")
+  attr(cp_vec, "locReason") <- c("fallback", "fallback", "no_generated_local_fdr_thresholds")
+
+  combined_out <- .getCpUnsLocCombineCpWithMeta(cp_vec, gateCombn = "min")
+  cp_min <- combined_out[["min"]]
+
+  expect_equal(as.numeric(cp_min["stim1"]), 5.0)
+  expect_equal(as.numeric(cp_min["stim2"]), 5.0)
+  expect_equal(as.numeric(cp_min["uns"]), 5.0)
+
+  meta_comb <- .getCpUnsLocMetaFromCp(cp_min)
+  expect_false(any(meta_comb$locGenerated))
+  expect_false(any(meta_comb$locGeneratedDirect))
+  expect_true(all(meta_comb$locSource == "not_calculated"))
+  expect_true(all(meta_comb$locReason == "no_generated_local_fdr_threshold_to_combine"))
+})
+
 test_that("diagnostic tables compute frequencies matching threshold cutoffs", {
   df_uns <- data.frame(CD4 = c(0.5, 1.0, 1.5, 2.0, 2.5))
   attr(df_uns, "chnlCut") <- "CD4"

--- a/tests/testthat/test-gate-combn-min.R
+++ b/tests/testthat/test-gate-combn-min.R
@@ -1,0 +1,213 @@
+test_that("gateStim with gateCombn = 'min' applies minimum generated threshold across multi-condition batch", {
+  skip_if_not_installed("flowWorkspace")
+  skip_if_not_installed("flowCore")
+
+  exampleData <- getExampleData()
+  gs <- flowWorkspace::load_gs(exampleData$pathGs)
+  pathProjectMin <- file.path(tempdir(), "test_gate_combn_min")
+
+  on.exit(
+    {
+      if (dir.exists(pathProjectMin)) unlink(pathProjectMin, recursive = TRUE)
+      if (dir.exists(exampleData$pathGs)) unlink(exampleData$pathGs, recursive = TRUE)
+    },
+    add = TRUE
+  )
+
+  # Multi-condition batch: sample 1 is unstim, samples 2 and 4 are two stimulated conditions
+  batchListMulti <- list(batch1 = c(1L, 2L, 4L))
+
+  # Run with gateCombn = "min" on the multi-condition batch
+  invisible(gateStim(
+    .data = gs,
+    pathProject = pathProjectMin,
+    popGate = "root",
+    batchList = batchListMulti,
+    marker = exampleData$marker,
+    gateCombn = "min",
+    tolClust = NULL,
+    calcCytPosGates = FALSE
+  ))
+
+  gatesMin <- getStimGates(pathProjectMin)
+  expect_true(is.data.frame(gatesMin) && nrow(gatesMin) > 0L)
+
+  statsMin <- getStimStats(pathProjectMin)
+  expect_true(is.data.frame(statsMin) && nrow(statsMin) > 0L)
+
+  # Verify across markers that gateCombn = "min" applies identical combined threshold across the batch
+  for (m in unique(as.character(gatesMin$marker))) {
+    mGatesMin <- gatesMin[as.character(gatesMin$marker) == m, , drop = FALSE]
+    stimGatesMin <- mGatesMin[as.character(mGatesMin$ind) %in% c("2", "4"), , drop = FALSE]
+
+    # Both conditions in the batch receive identical combined gate
+    expect_equal(unname(stimGatesMin$gate[1]), unname(stimGatesMin$gate[2]))
+    expect_true(is.finite(stimGatesMin$gate[1]))
+  }
+
+  # Verify that statsMin has valid frequencies computed from the combined gate
+  expect_true(all(!is.na(statsMin$propStim)))
+  expect_true(all(!is.na(statsMin$propBs)))
+  expect_true(all(!is.na(statsMin$freqBs)))
+})
+
+test_that("gateStim with gateCombn = 'min' combines generated thresholds on distinct responses", {
+  skip_if_not_installed("flowWorkspace")
+  skip_if_not_installed("flowCore")
+
+  set.seed(123)
+  nCells <- 1500L
+
+  # Sample 1: Unstimulated control (negative peak at 1.0)
+  m1_uns <- stats::rnorm(nCells, mean = 1.0, sd = 0.25)
+
+  # Sample 2: Strong response (75% negative at 1.0, 25% positive at 4.5)
+  m1_stim_strong <- c(
+    stats::rnorm(nCells * 0.75, mean = 1.0, sd = 0.25),
+    stats::rnorm(nCells * 0.25, mean = 4.5, sd = 0.3)
+  )
+
+  # Sample 3: Moderate response (80% negative at 1.0, 20% positive at 3.2)
+  m1_stim_mod <- c(
+    stats::rnorm(nCells * 0.8, mean = 1.0, sd = 0.25),
+    stats::rnorm(nCells * 0.2, mean = 3.2, sd = 0.3)
+  )
+
+  mat1 <- matrix(m1_uns, ncol = 1, dimnames = list(NULL, "MarkerF1"))
+  mat2 <- matrix(m1_stim_strong, ncol = 1, dimnames = list(NULL, "MarkerF1"))
+  mat3 <- matrix(m1_stim_mod, ncol = 1, dimnames = list(NULL, "MarkerF1"))
+
+  ff1 <- flowCore::flowFrame(mat1)
+  ff2 <- flowCore::flowFrame(mat2)
+  ff3 <- flowCore::flowFrame(mat3)
+
+  fs <- flowCore::flowSet(list(ff1, ff2, ff3))
+  flowCore::sampleNames(fs) <- c("sample1", "sample2", "sample3")
+  gs <- flowWorkspace::GatingSet(fs)
+
+  pathProjectNo <- file.path(tempdir(), "test_distinct_no")
+  pathProjectMin <- file.path(tempdir(), "test_distinct_min")
+  on.exit(
+    {
+      if (dir.exists(pathProjectNo)) unlink(pathProjectNo, recursive = TRUE)
+      if (dir.exists(pathProjectMin)) unlink(pathProjectMin, recursive = TRUE)
+    },
+    add = TRUE
+  )
+
+  batchList <- list(batch1 = c(1L, 2L, 3L))
+
+  # Gating with gateCombn = "no"
+  invisible(gateStim(
+    .data = gs,
+    pathProject = pathProjectNo,
+    popGate = "root",
+    batchList = batchList,
+    marker = "MarkerF1",
+    gateCombn = "no",
+    tolClust = NULL,
+    calcCytPosGates = FALSE
+  ))
+  gatesNo <- getStimGates(pathProjectNo)
+  gateStrong <- gatesNo$gate[as.character(gatesNo$ind) == "2"]
+  gateMod <- gatesNo$gate[as.character(gatesNo$ind) == "3"]
+  expect_true(gateStrong > gateMod)
+
+  # Gating with gateCombn = "min"
+  invisible(gateStim(
+    .data = gs,
+    pathProject = pathProjectMin,
+    popGate = "root",
+    batchList = batchList,
+    marker = "MarkerF1",
+    gateCombn = "min",
+    tolClust = NULL,
+    calcCytPosGates = FALSE
+  ))
+  gatesMin <- getStimGates(pathProjectMin)
+  expect_equal(
+    unname(gatesMin$gate[as.character(gatesMin$ind) == "2"]),
+    unname(gateMod),
+    tolerance = 1e-6
+  )
+  expect_equal(
+    unname(gatesMin$gate[as.character(gatesMin$ind) == "3"]),
+    unname(gateMod),
+    tolerance = 1e-6
+  )
+})
+
+test_that("gateStim with gateCombn = 'min' ignores fallback non-generated cutpoints in multi-condition batch", {
+  skip_if_not_installed("flowWorkspace")
+  skip_if_not_installed("flowCore")
+
+  set.seed(42)
+  nCells <- 1200L
+
+  # Sample 1: Unstimulated control (negative peak at 1.0)
+  m1_uns <- stats::rnorm(nCells, mean = 1.0, sd = 0.25)
+
+  # Sample 2: Responsive condition (80% negative at 1.0, 20% positive at 4.0)
+  m1_stim_resp <- c(
+    stats::rnorm(nCells * 0.8, mean = 1.0, sd = 0.25),
+    stats::rnorm(nCells * 0.2, mean = 4.0, sd = 0.3)
+  )
+
+  # Sample 3: Non-responsive condition (100% negative at 1.0, identical distribution to unstim)
+  m1_stim_nonresp <- stats::rnorm(nCells, mean = 1.0, sd = 0.25)
+
+  mat1 <- matrix(m1_uns, ncol = 1, dimnames = list(NULL, "MarkerF1"))
+  mat2 <- matrix(m1_stim_resp, ncol = 1, dimnames = list(NULL, "MarkerF1"))
+  mat3 <- matrix(m1_stim_nonresp, ncol = 1, dimnames = list(NULL, "MarkerF1"))
+
+  ff1 <- flowCore::flowFrame(mat1)
+  ff2 <- flowCore::flowFrame(mat2)
+  ff3 <- flowCore::flowFrame(mat3)
+
+  fs <- flowCore::flowSet(list(ff1, ff2, ff3))
+  flowCore::sampleNames(fs) <- c("sample1", "sample2", "sample3")
+  gs <- flowWorkspace::GatingSet(fs)
+
+  pathProject <- file.path(tempdir(), "test_gate_combn_fallback")
+  on.exit(
+    {
+      if (dir.exists(pathProject)) unlink(pathProject, recursive = TRUE)
+    },
+    add = TRUE
+  )
+
+  batchList <- list(batch1 = c(1L, 2L, 3L))
+
+  invisible(gateStim(
+    .data = gs,
+    pathProject = pathProject,
+    popGate = "root",
+    batchList = batchList,
+    marker = "MarkerF1",
+    gateCombn = "min",
+    tolClust = NULL,
+    calcCytPosGates = FALSE
+  ))
+
+  gates <- getStimGates(pathProject)
+  expect_true(is.data.frame(gates) && nrow(gates) > 0L)
+
+  gatesStim <- gates[as.character(gates$ind) %in% c("2", "3"), , drop = FALSE]
+
+  # Sample 2 generated a real threshold in [1.8, 3.5]
+  gateSample2 <- gatesStim$gate[as.character(gatesStim$ind) == "2"]
+  expect_true(gateSample2 > 1.8 && gateSample2 < 3.5)
+
+  # Sample 3 received Sample 2's generated threshold via min combination (not a fallback cutpoint)
+  expect_equal(
+    unname(gatesStim$gate[as.character(gatesStim$ind) == "3"]),
+    unname(gateSample2),
+    tolerance = 1e-6
+  )
+
+  # Stats reflect the combined gate
+  stats <- getStimStats(pathProject)
+  expect_true(is.data.frame(stats) && nrow(stats) > 0L)
+  expect_true(all(!is.na(stats$propStim)))
+  expect_true(all(!is.na(stats$propBs)))
+})


### PR DESCRIPTION
### Summary of Changes

Closes #346 (under parent Epic #345).

1. **Explicit `gateCombn = "min"` configuration in benchmark and analysis runs**:
   - In [`analysis/7-sim-compare-freq_bs.qmd`](file:///workspaces/stimgate/stimgate/analysis/7-sim-compare-freq_bs.qmd): explicitly declared `stimgate_gate_combn <- "min"`, included `gate_combn` in the simulation grid and `run_ctx` parameters, and forwarded `gateCombn = stimgate_gate_combn` to `.simCompareFreqBsGrid()`.
   - In [`analysis/8-sim-compare-freq_bs-batch.qmd`](file:///workspaces/stimgate/stimgate/analysis/8-sim-compare-freq_bs-batch.qmd): explicitly passed `gateCombn = "min"` to `.simCompareFreqBsGrid()`.
   - In [`scripts/r/sim-compare-freq_bs.R`](file:///workspaces/stimgate/stimgate/scripts/r/sim-compare-freq_bs.R): extracted and forwarded `gateCombn` in `.simCompareRunScenario()` and formatted `gate_combn` in scenario logging.

2. **Accurate provenance tracking for `gateCombn = "min"`**:
   - In [`R/cp_uns_loc.R`](file:///workspaces/stimgate/stimgate/R/cp_uns_loc.R#L380-L395): refined `.getCpUnsLocCombineCpWithMeta()` so that for combined batches, `locGeneratedDirect` is `TRUE` (`locSource = "direct"`) for the stimulated sample whose own detected threshold matches the minimum, and `FALSE` (`locSource = "combined"`, `locReason = "combined_from_generated_local_fdr_thresholds"`) for samples whose cutpoints were lowered or imputed from other stimulated conditions.

3. **Regression testing & verification**:
   - In [`tests/testthat/test-cp_uns_loc_threshold.R`](file:///workspaces/stimgate/stimgate/tests/testthat/test-cp_uns_loc_threshold.R): added unit tests verifying that `.getCpUnsLocCombineCpWithMeta()` uses the minimum of generated stimulated thresholds, completely ignores fallback non-generated cutpoints, and cleanly handles all-fallback conditions.
   - In [`tests/testthat/test-gate-combn-min.R`](file:///workspaces/stimgate/stimgate/tests/testthat/test-gate-combn-min.R): added end-to-end integration tests confirming on multi-condition batches that:
     - `gateStim(..., gateCombn = "min")` applies the minimum generated threshold across all stimulated samples in the batch.
     - Generated thresholds from distinct stimulated conditions combine to the minimum.
     - Non-responsive/fallback conditions in a multi-condition batch do not incorrectly become the minimum; they receive the lowest generated threshold.
     - Final gates from `getStimGates()` and frequencies from `getStimStats()` demonstrably reflect the combined minimum.
   - In [`analysis/tests/testthat/test-wrapper-api.R`](file:///workspaces/stimgate/stimgate/analysis/tests/testthat/test-wrapper-api.R): added checks ensuring analysis wrappers accept and default/forward `gateCombn = "min"`.

### Test Results
- Package test suite (`devtools::test()`): 713 passed, 0 failed, 3 skipped.
- Analysis test suite (`Rscript analysis/tests/run_analysis_tests.R`): 729 passed, 0 failed, 1 skipped.