### PR TITLE
Add hierarchical debug profiling for StimGate runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,9 @@ pkgdown::check_pkgdown()
   - `cyt_pos_gates-helper.R`: Helper functions for cytokine-positive cell gates.
   - `cyt_pos_gates.R`: Functions for more aggressive gates applied to cytokine-positive cells.
   - `debug.R`: Debugging utilities (`.debug()`) and global variable declarations.
+  - `profile.R`: Structured debug timing, incremental persistence and final collation helpers.
+  - `zz_profile_instrumentation.R`: Debug-only profiling wrappers around selected workflow boundaries.
+  - `zzz_profile_run_start.R`: Resets profiling once at the start of each debug `gateStim()` run.
   - `ex.R`: Extract expression matrices from `GatingSet` objects.
   - `example_data.R`: Loads the canonical shipped example dataset via `getExampleData()` and does not simulate new data.
   - `fcs_write.R`: Write FCS files of cytokine-positive cells (`writeStimFCS`).
@@ -329,6 +332,20 @@ QMD runtime or unrelated plotting/orchestration code.
   is written to a temp file and controlled by the `STIMGATE_DEBUG` environment
   variable (set to `"true"`, `"yes"`, `"y"`, or `"1"` to enable).
   Do **NOT** add a debug flag or parameter to function signatures.
+- Debug mode also enables structured timing profiles under `pathProject/profile/`.
+  Each completed timing unit is saved immediately as a small RDS record under
+  `profile/raw/`; a successful run collates these records into `profile/profile.rds`
+  and `profile/profile.csv`. A new debug `gateStim()` run removes the previous
+  `profile/` directory first. Profiling failures must never fail the gating run.
+- Keep profiling selective. Record broad workflow stages generally, but detailed
+  per-sample timings are currently reserved for initial local-FDR gating. The
+  selected sample-level detail is the probability model, density/bandwidth work,
+  antimode work, filtering/threshold work and marginal filtering. Do not add a
+  timer for every debug statement or small helper without evidence that it is
+  useful for diagnosing run time.
+- `zz_profile_instrumentation.R` deliberately loads after the implementation files
+  and wraps selected internal functions without changing their arguments. Preserve
+  wrapped function signatures when profiling boundaries change.
 - Use the `stage` parameter to track algorithm stages (`"init"`, `"cytPos"`, or
   `"single"`). Pass `stage` through function calls to enable intermediate data
   saving via `.intSave()` or `.intSaveNm()` functions. Intermediate saving is

--- a/R/profile.R
+++ b/R/profile.R
@@ -1,0 +1,455 @@
+# Debug profiling helpers ----------------------------------------------------
+
+.profileState <- new.env(parent = emptyenv())
+.profileState$initialized <- FALSE
+.profileState$pathProject <- NULL
+.profileState$rawDir <- NULL
+.profileState$context <- list(
+  marker = NA_character_,
+  channel = NA_character_,
+  batch = NA_character_,
+  sample = NA_character_,
+  stage = NA_character_
+)
+.profileState$stack <- character()
+.profileState$runTimer <- NULL
+
+#' @keywords internal
+.profileEnabled <- function() {
+  tolower(trimws(Sys.getenv("STIMGATE_DEBUG"))) %in%
+    c("y", "true", "yes", "1")
+}
+
+#' @keywords internal
+.profilePath <- function(pathProject) {
+  file.path(pathProject, "profile")
+}
+
+#' @keywords internal
+.profileNormalisePath <- function(pathProject) {
+  normalizePath(pathProject, winslash = "/", mustWork = FALSE)
+}
+
+#' @keywords internal
+.profileContextDefault <- function() {
+  list(
+    marker = NA_character_,
+    channel = NA_character_,
+    batch = NA_character_,
+    sample = NA_character_,
+    stage = NA_character_
+  )
+}
+
+#' @keywords internal
+.profileMessage <- function(msg) {
+  if (.profileEnabled()) {
+    message("StimGate profiling: ", msg)
+  }
+  invisible(FALSE)
+}
+
+#' @keywords internal
+.profileStateReset <- function() {
+  .profileState$initialized <- FALSE
+  .profileState$pathProject <- NULL
+  .profileState$rawDir <- NULL
+  .profileState$context <- .profileContextDefault()
+  .profileState$stack <- character()
+  .profileState$runTimer <- NULL
+  invisible(TRUE)
+}
+
+#' Start a fresh profile directory for a StimGate run
+#' @keywords internal
+.profileInit <- function(pathProject) {
+  if (!.profileEnabled()) {
+    return(invisible(FALSE))
+  }
+
+  tryCatch(
+    {
+      pathProject <- .profileNormalisePath(pathProject)
+      pathProfile <- .profilePath(pathProject)
+      if (dir.exists(pathProfile)) {
+        unlink(pathProfile, recursive = TRUE, force = TRUE)
+      }
+      rawDir <- file.path(pathProfile, "raw")
+      dir.create(rawDir, recursive = TRUE, showWarnings = FALSE)
+      if (!dir.exists(rawDir)) {
+        stop("could not create profile/raw directory")
+      }
+
+      .profileState$initialized <- TRUE
+      .profileState$pathProject <- pathProject
+      .profileState$rawDir <- rawDir
+      .profileState$context <- .profileContextDefault()
+      .profileState$stack <- character()
+      .profileState$runTimer <- .profileStart(
+        level = "run",
+        major = "gateStim",
+        operation = "gateStim",
+        pathProject = pathProject
+      )
+      invisible(TRUE)
+    },
+    error = function(e) {
+      .profileStateReset()
+      .profileMessage(conditionMessage(e))
+      invisible(FALSE)
+    }
+  )
+}
+
+#' Attach profiling state without deleting existing raw records
+#'
+#' This is mainly a safeguard for worker processes that enter a profiled helper
+#' after the main process has already created the profile directory.
+#' @keywords internal
+.profileAttach <- function(pathProject) {
+  if (!.profileEnabled()) {
+    return(invisible(FALSE))
+  }
+
+  tryCatch(
+    {
+      pathProject <- .profileNormalisePath(pathProject)
+      rawDir <- file.path(.profilePath(pathProject), "raw")
+      dir.create(rawDir, recursive = TRUE, showWarnings = FALSE)
+      if (!dir.exists(rawDir)) {
+        stop("could not attach to profile/raw directory")
+      }
+      .profileState$initialized <- TRUE
+      .profileState$pathProject <- pathProject
+      .profileState$rawDir <- rawDir
+      .profileState$context <- .profileContextDefault()
+      .profileState$stack <- character()
+      .profileState$runTimer <- NULL
+      invisible(TRUE)
+    },
+    error = function(e) {
+      .profileStateReset()
+      .profileMessage(conditionMessage(e))
+      invisible(FALSE)
+    }
+  )
+}
+
+#' @keywords internal
+.profileEnsureAttached <- function(pathProject = NULL) {
+  if (!.profileEnabled()) {
+    return(FALSE)
+  }
+  if (isTRUE(.profileState$initialized)) {
+    return(TRUE)
+  }
+  if (is.null(pathProject) || length(pathProject) == 0L) {
+    return(FALSE)
+  }
+  isTRUE(.profileAttach(pathProject))
+}
+
+#' Temporarily add profiling context
+#' @keywords internal
+.profileWithContext <- function(
+    expr,
+    marker = NULL,
+    channel = NULL,
+    batch = NULL,
+    sample = NULL,
+    stage = NULL) {
+  if (!.profileEnabled()) {
+    return(force(expr))
+  }
+
+  oldContext <- .profileState$context
+  newContext <- oldContext
+  values <- list(
+    marker = marker,
+    channel = channel,
+    batch = batch,
+    sample = sample,
+    stage = stage
+  )
+  for (name in names(values)) {
+    value <- values[[name]]
+    if (!is.null(value) && length(value) > 0L) {
+      newContext[[name]] <- as.character(value[[1L]])
+    }
+  }
+  .profileState$context <- newContext
+  on.exit({
+    .profileState$context <- oldContext
+  }, add = TRUE)
+
+  value <- withVisible(force(expr))
+  if (isTRUE(value$visible)) {
+    value$value
+  } else {
+    invisible(value$value)
+  }
+}
+
+#' @keywords internal
+.profileStart <- function(
+    level,
+    major,
+    minor = NA_character_,
+    operation = NA_character_,
+    pathProject = NULL) {
+  if (!.profileEnsureAttached(pathProject)) {
+    return(NULL)
+  }
+
+  rawDir <- .profileState$rawDir
+  pathRecord <- tempfile(
+    pattern = "profile-",
+    tmpdir = rawDir,
+    fileext = ".rds"
+  )
+  recordId <- sub("\\.rds$", "", basename(pathRecord))
+  stack <- .profileState$stack
+  depth <- length(stack)
+  parentId <- if (depth == 0L) NA_character_ else stack[[depth]]
+  context <- .profileState$context
+
+  timer <- list(
+    recordId = recordId,
+    parentId = parentId,
+    pathRecord = pathRecord,
+    depth = depth,
+    level = as.character(level[[1L]]),
+    major = as.character(major[[1L]]),
+    minor = as.character(minor[[1L]]),
+    operation = as.character(operation[[1L]]),
+    marker = context$marker,
+    channel = context$channel,
+    batch = context$batch,
+    sample = context$sample,
+    stage = context$stage,
+    pid = Sys.getpid(),
+    startedAt = format(
+      Sys.time(),
+      "%Y-%m-%dT%H:%M:%OS3%z"
+    ),
+    startedElapsed = proc.time()[["elapsed"]]
+  )
+  .profileState$stack <- c(stack, recordId)
+  timer
+}
+
+#' @keywords internal
+.profilePop <- function(recordId) {
+  stack <- .profileState$stack
+  if (length(stack) == 0L) {
+    return(invisible(FALSE))
+  }
+  matchInd <- which(stack == recordId)
+  if (length(matchInd) == 0L) {
+    return(invisible(FALSE))
+  }
+  removeInd <- matchInd[[length(matchInd)]]
+  .profileState$stack <- stack[-removeInd]
+  invisible(TRUE)
+}
+
+#' @keywords internal
+.profileWriteRecord <- function(record, pathRecord) {
+  tryCatch(
+    {
+      saveRDS(record, pathRecord)
+      invisible(TRUE)
+    },
+    error = function(e) {
+      .profileMessage(
+        paste0("could not write timing record: ", conditionMessage(e))
+      )
+      invisible(FALSE)
+    }
+  )
+}
+
+#' Finish one profiling timer and persist it immediately
+#' @keywords internal
+.profileStop <- function(timer) {
+  if (is.null(timer)) {
+    return(invisible(NULL))
+  }
+
+  elapsed <- proc.time()[["elapsed"]] - timer$startedElapsed
+  finishedAt <- format(
+    Sys.time(),
+    "%Y-%m-%dT%H:%M:%OS3%z"
+  )
+  .profilePop(timer$recordId)
+
+  record <- data.frame(
+    record_id = timer$recordId,
+    parent_id = timer$parentId,
+    depth = as.integer(timer$depth),
+    level = timer$level,
+    major = timer$major,
+    minor = timer$minor,
+    operation = timer$operation,
+    marker = timer$marker,
+    channel = timer$channel,
+    batch = timer$batch,
+    sample = timer$sample,
+    stage = timer$stage,
+    pid = as.integer(timer$pid),
+    elapsed_sec = as.numeric(elapsed),
+    started_at = timer$startedAt,
+    finished_at = finishedAt,
+    status = "completed",
+    stringsAsFactors = FALSE
+  )
+  .profileWriteRecord(record, timer$pathRecord)
+  invisible(record)
+}
+
+#' Discard an unfinished timer while restoring the hierarchy stack
+#' @keywords internal
+.profileCancel <- function(timer) {
+  if (!is.null(timer)) {
+    .profilePop(timer$recordId)
+  }
+  invisible(FALSE)
+}
+
+#' Time one expression and persist the completed timing record
+#' @keywords internal
+.profileTime <- function(
+    expr,
+    level,
+    major,
+    minor = NA_character_,
+    operation = NA_character_,
+    pathProject = NULL) {
+  if (!.profileEnabled()) {
+    return(force(expr))
+  }
+
+  timer <- .profileStart(
+    level = level,
+    major = major,
+    minor = minor,
+    operation = operation,
+    pathProject = pathProject
+  )
+  if (is.null(timer)) {
+    return(force(expr))
+  }
+
+  completed <- FALSE
+  on.exit({
+    if (!completed) {
+      .profileCancel(timer)
+    }
+  }, add = TRUE)
+
+  value <- withVisible(force(expr))
+  .profileStop(timer)
+  completed <- TRUE
+  if (isTRUE(value$visible)) {
+    value$value
+  } else {
+    invisible(value$value)
+  }
+}
+
+#' @keywords internal
+.profileDataBatch <- function(.data) {
+  batch <- attr(.data, "batch")
+  if (!is.null(batch) && length(batch) > 0L && !is.na(batch[[1L]])) {
+    return(as.character(batch[[1L]]))
+  }
+  if (
+    is.data.frame(.data) &&
+      "batch" %in% names(.data) &&
+      nrow(.data) > 0L &&
+      !is.na(.data$batch[[1L]])
+  ) {
+    return(as.character(.data$batch[[1L]]))
+  }
+  NA_character_
+}
+
+#' @keywords internal
+.profileInitialSampleActive <- function() {
+  context <- .profileState$context
+  identical(context$stage, "init") &&
+    !is.na(context$sample) &&
+    nzchar(context$sample)
+}
+
+#' Merge the incrementally saved timing records
+#' @keywords internal
+.profileFinalise <- function(pathProject = .profileState$pathProject) {
+  if (!.profileEnabled() || is.null(pathProject)) {
+    return(invisible(NULL))
+  }
+
+  tryCatch(
+    {
+      pathProfile <- .profilePath(.profileNormalisePath(pathProject))
+      rawDir <- file.path(pathProfile, "raw")
+      files <- list.files(
+        rawDir,
+        pattern = "\\.rds$",
+        full.names = TRUE
+      )
+      if (length(files) == 0L) {
+        return(invisible(NULL))
+      }
+
+      records <- lapply(files, function(path) {
+        tryCatch(readRDS(path), error = function(e) NULL)
+      })
+      records <- Filter(Negate(is.null), records)
+      if (length(records) == 0L) {
+        return(invisible(NULL))
+      }
+
+      profileTbl <- do.call(rbind, records)
+      ord <- order(
+        profileTbl$started_at,
+        profileTbl$depth,
+        profileTbl$record_id
+      )
+      profileTbl <- profileTbl[ord, , drop = FALSE]
+      rownames(profileTbl) <- NULL
+
+      saveRDS(profileTbl, file.path(pathProfile, "profile.rds"))
+      utils::write.csv(
+        profileTbl,
+        file.path(pathProfile, "profile.csv"),
+        row.names = FALSE,
+        na = ""
+      )
+      invisible(profileTbl)
+    },
+    error = function(e) {
+      .profileMessage(
+        paste0("could not collate profiling records: ", conditionMessage(e))
+      )
+      invisible(NULL)
+    }
+  )
+}
+
+#' Finish the run timer and collate the final profile
+#' @keywords internal
+.profileFinishRun <- function(pathProject = .profileState$pathProject) {
+  if (!.profileEnabled() || !isTRUE(.profileState$initialized)) {
+    return(invisible(NULL))
+  }
+
+  runTimer <- .profileState$runTimer
+  if (!is.null(runTimer)) {
+    .profileStop(runTimer)
+    .profileState$runTimer <- NULL
+  }
+  profileTbl <- .profileFinalise(pathProject)
+  .profileStateReset()
+  invisible(profileTbl)
+}

--- a/R/profile.R
+++ b/R/profile.R
@@ -62,7 +62,7 @@
 
 #' Start a fresh profile directory for a StimGate run
 #' @keywords internal
-.profileInit <- function(pathProject) {
+.profileInit <- function(pathProject, reset = FALSE) {
   if (!.profileEnabled()) {
     return(invisible(FALSE))
   }
@@ -70,6 +70,14 @@
   tryCatch(
     {
       pathProject <- .profileNormalisePath(pathProject)
+      if (
+        isTRUE(.profileState$initialized) &&
+          identical(.profileState$pathProject, pathProject) &&
+          !isTRUE(reset)
+      ) {
+        return(invisible(TRUE))
+      }
+
       pathProfile <- .profilePath(pathProject)
       if (dir.exists(pathProfile)) {
         unlink(pathProfile, recursive = TRUE, force = TRUE)

--- a/R/zz_profile_instrumentation.R
+++ b/R/zz_profile_instrumentation.R
@@ -1,0 +1,551 @@
+# Debug profiling instrumentation -------------------------------------------
+#
+# This file is deliberately prefixed with `zz_` so the implementation
+# functions it wraps have already been defined. The wrappers add only debug
+# profiling and delegate unchanged to the original implementation otherwise.
+
+.profileOriginalGateInit <- .gateInit
+.profileOriginalGateCytPos <- .gateCytPos
+.profileOriginalGateStats <- .gateStats
+.profileOriginalGateChnl <- .gateChnl
+.profileOriginalGateBatch <- .gateBatch
+.profileOriginalGetCpUnsLoc <- .getCpUnsLoc
+.profileOriginalGetCpCluster <- .getCpCluster
+.profileOriginalGetCpUnsLocCondition <- .getCpUnsLocCondition
+.profileOriginalGetCpUnsLocGetProb <- .getCpUnsLocGetProb
+.profileOriginalGetCpUnsLocGetDensRawDensities <-
+  .getCpUnsLocGetDensRawDensities
+.profileOriginalGetCpUnsLocAntimodeDensity <- .getCpUnsLocAntimodeDensity
+.profileOriginalGetCpUnsLocGetCp <- .getCpUnsLocGetCp
+.profileOriginalGetCpUnsLocFilterMarginal <- .getCpUnsLocFilterMarginal
+
+.gateInit <- function(
+    chnlSettings,
+    .data,
+    indBatchList,
+    pathProject) {
+  if (!.profileEnabled()) {
+    return(.profileOriginalGateInit(
+      chnlSettings = chnlSettings,
+      .data = .data,
+      indBatchList = indBatchList,
+      pathProject = pathProject
+    ))
+  }
+
+  .profileInit(pathProject)
+  .profileWithContext(
+    .profileTime(
+      .profileOriginalGateInit(
+        chnlSettings = chnlSettings,
+        .data = .data,
+        indBatchList = indBatchList,
+        pathProject = pathProject
+      ),
+      level = "major",
+      major = "initial_gating",
+      operation = "initial_gating",
+      pathProject = pathProject
+    ),
+    stage = "init"
+  )
+}
+
+.gateCytPos <- function(
+    chnlSettings,
+    indBatchList,
+    .data,
+    gateName = NULL,
+    calcCytPos = TRUE,
+    stage,
+    pathProject) {
+  if (!.profileEnabled()) {
+    return(.profileOriginalGateCytPos(
+      chnlSettings = chnlSettings,
+      indBatchList = indBatchList,
+      .data = .data,
+      gateName = gateName,
+      calcCytPos = calcCytPos,
+      stage = stage,
+      pathProject = pathProject
+    ))
+  }
+
+  .profileWithContext(
+    .profileTime(
+      .profileOriginalGateCytPos(
+        chnlSettings = chnlSettings,
+        indBatchList = indBatchList,
+        .data = .data,
+        gateName = gateName,
+        calcCytPos = calcCytPos,
+        stage = stage,
+        pathProject = pathProject
+      ),
+      level = "major",
+      major = "cytokine_positive_gating",
+      operation = "cytokine_positive_gating",
+      pathProject = pathProject
+    ),
+    stage = stage
+  )
+}
+
+.gateStats <- function(
+    .data,
+    gateTbl = NULL,
+    calcCytPosGates,
+    chnlSettings,
+    indBatchList,
+    pathProject) {
+  if (!.profileEnabled()) {
+    return(.profileOriginalGateStats(
+      .data = .data,
+      gateTbl = gateTbl,
+      calcCytPosGates = calcCytPosGates,
+      chnlSettings = chnlSettings,
+      indBatchList = indBatchList,
+      pathProject = pathProject
+    ))
+  }
+
+  out <- .profileWithContext(
+    .profileTime(
+      .profileOriginalGateStats(
+        .data = .data,
+        gateTbl = gateTbl,
+        calcCytPosGates = calcCytPosGates,
+        chnlSettings = chnlSettings,
+        indBatchList = indBatchList,
+        pathProject = pathProject
+      ),
+      level = "major",
+      major = "final_statistics",
+      operation = "final_statistics",
+      pathProject = pathProject
+    ),
+    stage = "stats"
+  )
+  .profileFinishRun(pathProject)
+  out
+}
+
+.gateChnl <- function(
+    .data,
+    indBatchList,
+    chnlSettings,
+    gateTbl = NULL,
+    tolGateSingle = NULL,
+    calcCytPosGates,
+    pathProject,
+    stage) {
+  if (!.profileEnabled() || !identical(stage, "init")) {
+    return(.profileOriginalGateChnl(
+      .data = .data,
+      indBatchList = indBatchList,
+      chnlSettings = chnlSettings,
+      gateTbl = gateTbl,
+      tolGateSingle = tolGateSingle,
+      calcCytPosGates = calcCytPosGates,
+      pathProject = pathProject,
+      stage = stage
+    ))
+  }
+
+  marker <- chnlSettings$marker %||% chnlSettings$chnlCut
+  .profileWithContext(
+    .profileTime(
+      .profileOriginalGateChnl(
+        .data = .data,
+        indBatchList = indBatchList,
+        chnlSettings = chnlSettings,
+        gateTbl = gateTbl,
+        tolGateSingle = tolGateSingle,
+        calcCytPosGates = calcCytPosGates,
+        pathProject = pathProject,
+        stage = stage
+      ),
+      level = "minor",
+      major = "initial_gating",
+      minor = "marker",
+      operation = "marker_total",
+      pathProject = pathProject
+    ),
+    marker = marker,
+    channel = chnlSettings$chnlCut,
+    stage = stage
+  )
+}
+
+.gateBatch <- function(
+    .data,
+    indBatch,
+    chnlSettings,
+    batch,
+    stage,
+    pathProject) {
+  if (!.profileEnabled() || !identical(stage, "init")) {
+    return(.profileOriginalGateBatch(
+      .data = .data,
+      indBatch = indBatch,
+      chnlSettings = chnlSettings,
+      batch = batch,
+      stage = stage,
+      pathProject = pathProject
+    ))
+  }
+
+  .profileWithContext(
+    .profileTime(
+      .profileOriginalGateBatch(
+        .data = .data,
+        indBatch = indBatch,
+        chnlSettings = chnlSettings,
+        batch = batch,
+        stage = stage,
+        pathProject = pathProject
+      ),
+      level = "minor",
+      major = "initial_gating",
+      minor = "batch",
+      operation = "batch_total",
+      pathProject = pathProject
+    ),
+    batch = batch,
+    stage = stage
+  )
+}
+
+.getCpUnsLoc <- function(
+    exList,
+    .data,
+    chnlSettings,
+    stage,
+    pathProject) {
+  if (!.profileEnabled() || !identical(stage, "init")) {
+    return(.profileOriginalGetCpUnsLoc(
+      exList = exList,
+      .data = .data,
+      chnlSettings = chnlSettings,
+      stage = stage,
+      pathProject = pathProject
+    ))
+  }
+
+  .profileTime(
+    .profileOriginalGetCpUnsLoc(
+      exList = exList,
+      .data = .data,
+      chnlSettings = chnlSettings,
+      stage = stage,
+      pathProject = pathProject
+    ),
+    level = "minor",
+    major = "initial_gating",
+    minor = "local_fdr",
+    operation = "local_fdr_initial_gating",
+    pathProject = pathProject
+  )
+}
+
+.getCpCluster <- function(
+    .data,
+    gateTbl,
+    gateStatsTbl,
+    gateTblCtrl,
+    chnlSettings,
+    stage,
+    pathProject,
+    control = list(),
+    filterOtherCytPos,
+    calcCytPosGates,
+    indBatchList) {
+  if (!.profileEnabled() || !identical(stage, "init")) {
+    return(.profileOriginalGetCpCluster(
+      .data = .data,
+      gateTbl = gateTbl,
+      gateStatsTbl = gateStatsTbl,
+      gateTblCtrl = gateTblCtrl,
+      chnlSettings = chnlSettings,
+      stage = stage,
+      pathProject = pathProject,
+      control = control,
+      filterOtherCytPos = filterOtherCytPos,
+      calcCytPosGates = calcCytPosGates,
+      indBatchList = indBatchList
+    ))
+  }
+
+  .profileTime(
+    .profileOriginalGetCpCluster(
+      .data = .data,
+      gateTbl = gateTbl,
+      gateStatsTbl = gateStatsTbl,
+      gateTblCtrl = gateTblCtrl,
+      chnlSettings = chnlSettings,
+      stage = stage,
+      pathProject = pathProject,
+      control = control,
+      filterOtherCytPos = filterOtherCytPos,
+      calcCytPosGates = calcCytPosGates,
+      indBatchList = indBatchList
+    ),
+    level = "minor",
+    major = "initial_gating",
+    minor = "cross_sample",
+    operation = "cluster_refinement",
+    pathProject = pathProject
+  )
+}
+
+.getCpUnsLocCondition <- function(
+    exTblUnsBias,
+    exTblStimNoMin,
+    chnlSettings,
+    exTblStimOrig,
+    exTblUnsOrig,
+    plot = TRUE,
+    probMin = 0.1,
+    bias,
+    pathProject,
+    stage) {
+  if (!.profileEnabled() || !identical(stage, "init")) {
+    return(.profileOriginalGetCpUnsLocCondition(
+      exTblUnsBias = exTblUnsBias,
+      exTblStimNoMin = exTblStimNoMin,
+      chnlSettings = chnlSettings,
+      exTblStimOrig = exTblStimOrig,
+      exTblUnsOrig = exTblUnsOrig,
+      plot = plot,
+      probMin = probMin,
+      bias = bias,
+      pathProject = pathProject,
+      stage = stage
+    ))
+  }
+
+  batch <- .profileDataBatch(exTblStimNoMin)
+  if (is.na(batch)) {
+    batch <- NULL
+  }
+  sample <- as.character(.getInd(exTblStimNoMin))
+  marker <- chnlSettings$marker %||% chnlSettings$chnlCut
+
+  .profileWithContext(
+    .profileTime(
+      .profileOriginalGetCpUnsLocCondition(
+        exTblUnsBias = exTblUnsBias,
+        exTblStimNoMin = exTblStimNoMin,
+        chnlSettings = chnlSettings,
+        exTblStimOrig = exTblStimOrig,
+        exTblUnsOrig = exTblUnsOrig,
+        plot = plot,
+        probMin = probMin,
+        bias = bias,
+        pathProject = pathProject,
+        stage = stage
+      ),
+      level = "sample",
+      major = "initial_gating",
+      minor = "local_fdr",
+      operation = "sample_initial_gating",
+      pathProject = pathProject
+    ),
+    marker = marker,
+    channel = chnlSettings$chnlCut,
+    batch = batch,
+    sample = sample,
+    stage = stage
+  )
+}
+
+.getCpUnsLocGetProb <- function(
+    exTblStimNoMin,
+    exTblStimThreshold,
+    exTblUnsThreshold,
+    exTblUnsBias,
+    bias,
+    exTblUnsOrig,
+    stage,
+    pathProject,
+    chnlSettings) {
+  if (!.profileEnabled() || !.profileInitialSampleActive()) {
+    return(.profileOriginalGetCpUnsLocGetProb(
+      exTblStimNoMin = exTblStimNoMin,
+      exTblStimThreshold = exTblStimThreshold,
+      exTblUnsThreshold = exTblUnsThreshold,
+      exTblUnsBias = exTblUnsBias,
+      bias = bias,
+      exTblUnsOrig = exTblUnsOrig,
+      stage = stage,
+      pathProject = pathProject,
+      chnlSettings = chnlSettings
+    ))
+  }
+
+  .profileTime(
+    .profileOriginalGetCpUnsLocGetProb(
+      exTblStimNoMin = exTblStimNoMin,
+      exTblStimThreshold = exTblStimThreshold,
+      exTblUnsThreshold = exTblUnsThreshold,
+      exTblUnsBias = exTblUnsBias,
+      bias = bias,
+      exTblUnsOrig = exTblUnsOrig,
+      stage = stage,
+      pathProject = pathProject,
+      chnlSettings = chnlSettings
+    ),
+    level = "sample_minor",
+    major = "initial_gating",
+    minor = "local_fdr",
+    operation = "probability_model",
+    pathProject = pathProject
+  )
+}
+
+.getCpUnsLocGetDensRawDensities <- function(
+    exTblStimThreshold,
+    exTblUnsThreshold,
+    stage,
+    pathProject,
+    chnlSettings) {
+  if (!.profileEnabled() || !.profileInitialSampleActive()) {
+    return(.profileOriginalGetCpUnsLocGetDensRawDensities(
+      exTblStimThreshold = exTblStimThreshold,
+      exTblUnsThreshold = exTblUnsThreshold,
+      stage = stage,
+      pathProject = pathProject,
+      chnlSettings = chnlSettings
+    ))
+  }
+
+  .profileTime(
+    .profileOriginalGetCpUnsLocGetDensRawDensities(
+      exTblStimThreshold = exTblStimThreshold,
+      exTblUnsThreshold = exTblUnsThreshold,
+      stage = stage,
+      pathProject = pathProject,
+      chnlSettings = chnlSettings
+    ),
+    level = "sample_detail",
+    major = "initial_gating",
+    minor = "local_fdr",
+    operation = "density_bandwidth",
+    pathProject = pathProject
+  )
+}
+
+.getCpUnsLocAntimodeDensity <- function(
+    expr,
+    chnlSettings,
+    originalBw = NULL,
+    mtd = c("taut_string", "kde")) {
+  if (!.profileEnabled() || !.profileInitialSampleActive()) {
+    return(.profileOriginalGetCpUnsLocAntimodeDensity(
+      expr = expr,
+      chnlSettings = chnlSettings,
+      originalBw = originalBw,
+      mtd = mtd
+    ))
+  }
+
+  .profileTime(
+    .profileOriginalGetCpUnsLocAntimodeDensity(
+      expr = expr,
+      chnlSettings = chnlSettings,
+      originalBw = originalBw,
+      mtd = mtd
+    ),
+    level = "sample_detail",
+    major = "initial_gating",
+    minor = "local_fdr",
+    operation = "antimode"
+  )
+}
+
+.getCpUnsLocGetCp <- function(
+    dataMod,
+    exTblStimOrig,
+    exTblStimNoMin,
+    exTblUnsOrig,
+    exTblUnsBias,
+    bias,
+    cpMin,
+    stage,
+    pathProject,
+    chnlSettings = list()) {
+  if (!.profileEnabled() || !.profileInitialSampleActive()) {
+    return(.profileOriginalGetCpUnsLocGetCp(
+      dataMod = dataMod,
+      exTblStimOrig = exTblStimOrig,
+      exTblStimNoMin = exTblStimNoMin,
+      exTblUnsOrig = exTblUnsOrig,
+      exTblUnsBias = exTblUnsBias,
+      bias = bias,
+      cpMin = cpMin,
+      stage = stage,
+      pathProject = pathProject,
+      chnlSettings = chnlSettings
+    ))
+  }
+
+  .profileTime(
+    .profileOriginalGetCpUnsLocGetCp(
+      dataMod = dataMod,
+      exTblStimOrig = exTblStimOrig,
+      exTblStimNoMin = exTblStimNoMin,
+      exTblUnsOrig = exTblUnsOrig,
+      exTblUnsBias = exTblUnsBias,
+      bias = bias,
+      cpMin = cpMin,
+      stage = stage,
+      pathProject = pathProject,
+      chnlSettings = chnlSettings
+    ),
+    level = "sample_minor",
+    major = "initial_gating",
+    minor = "local_fdr",
+    operation = "filtering_threshold",
+    pathProject = pathProject
+  )
+}
+
+.getCpUnsLocFilterMarginal <- function(
+    dataMod,
+    chnlSettings,
+    probCol,
+    antimodeX = NULL,
+    threshold = NULL,
+    dominance = NULL,
+    globalLowerBoundX = NA_real_,
+    shapeLowerBoundX = NA_real_) {
+  if (!.profileEnabled() || !.profileInitialSampleActive()) {
+    return(.profileOriginalGetCpUnsLocFilterMarginal(
+      dataMod = dataMod,
+      chnlSettings = chnlSettings,
+      probCol = probCol,
+      antimodeX = antimodeX,
+      threshold = threshold,
+      dominance = dominance,
+      globalLowerBoundX = globalLowerBoundX,
+      shapeLowerBoundX = shapeLowerBoundX
+    ))
+  }
+
+  .profileTime(
+    .profileOriginalGetCpUnsLocFilterMarginal(
+      dataMod = dataMod,
+      chnlSettings = chnlSettings,
+      probCol = probCol,
+      antimodeX = antimodeX,
+      threshold = threshold,
+      dominance = dominance,
+      globalLowerBoundX = globalLowerBoundX,
+      shapeLowerBoundX = shapeLowerBoundX
+    ),
+    level = "sample_detail",
+    major = "initial_gating",
+    minor = "local_fdr",
+    operation = "marginal_filtering"
+  )
+}

--- a/R/zzz_profile_run_start.R
+++ b/R/zzz_profile_run_start.R
@@ -1,0 +1,18 @@
+# Start debug profiling at the first project write ---------------------------
+#
+# gateStim() calls .saveMetaData() once after input verification and before
+# channel setup or gating. Wrapping that call gives each debug run a fresh
+# profile directory without changing the public gateStim() signature.
+
+.profileOriginalSaveMetaData <- .saveMetaData
+
+.saveMetaData <- function(.data, batchList, pathProject) {
+  if (.profileEnabled()) {
+    .profileInit(pathProject, reset = TRUE)
+  }
+  .profileOriginalSaveMetaData(
+    .data = .data,
+    batchList = batchList,
+    pathProject = pathProject
+  )
+}

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -3,6 +3,10 @@ test_that("profiling is disabled outside debug mode", {
   .profileStateReset()
   pathProject <- tempfile("stimgate-profile-off-")
   dir.create(pathProject, recursive = TRUE)
+  withr::defer({
+    .profileStateReset()
+    unlink(pathProject, recursive = TRUE, force = TRUE)
+  })
 
   expect_false(.profileInit(pathProject))
   expect_false(dir.exists(file.path(pathProject, "profile")))
@@ -12,6 +16,10 @@ test_that("a debug run resets and incrementally saves profiling records", {
   withr::local_envvar(c(STIMGATE_DEBUG = "true"))
   .profileStateReset()
   pathProject <- tempfile("stimgate-profile-")
+  withr::defer({
+    .profileStateReset()
+    unlink(pathProject, recursive = TRUE, force = TRUE)
+  })
   pathOldRaw <- file.path(pathProject, "profile", "raw")
   dir.create(pathOldRaw, recursive = TRUE)
   pathOld <- file.path(pathOldRaw, "old.rds")
@@ -50,6 +58,10 @@ test_that("profiling records explicit hierarchy and sample context", {
   withr::local_envvar(c(STIMGATE_DEBUG = "yes"))
   .profileStateReset()
   pathProject <- tempfile("stimgate-profile-hierarchy-")
+  withr::defer({
+    .profileStateReset()
+    unlink(pathProject, recursive = TRUE, force = TRUE)
+  })
   expect_true(.profileInit(pathProject))
 
   .profileWithContext(
@@ -102,7 +114,10 @@ test_that("profiling records explicit hierarchy and sample context", {
 })
 
 test_that("profiling instrumentation preserves wrapped function arguments", {
-  expect_identical(names(formals(.gateInit)), names(formals(.profileOriginalGateInit)))
+  expect_identical(
+    names(formals(.gateInit)),
+    names(formals(.profileOriginalGateInit))
+  )
   expect_identical(
     names(formals(.gateCytPos)),
     names(formals(.profileOriginalGateCytPos))

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -1,0 +1,134 @@
+test_that("profiling is disabled outside debug mode", {
+  withr::local_envvar(c(STIMGATE_DEBUG = "false"))
+  .profileStateReset()
+  pathProject <- tempfile("stimgate-profile-off-")
+  dir.create(pathProject, recursive = TRUE)
+
+  expect_false(.profileInit(pathProject))
+  expect_false(dir.exists(file.path(pathProject, "profile")))
+})
+
+test_that("a debug run resets and incrementally saves profiling records", {
+  withr::local_envvar(c(STIMGATE_DEBUG = "true"))
+  .profileStateReset()
+  pathProject <- tempfile("stimgate-profile-")
+  pathOldRaw <- file.path(pathProject, "profile", "raw")
+  dir.create(pathOldRaw, recursive = TRUE)
+  pathOld <- file.path(pathOldRaw, "old.rds")
+  saveRDS(data.frame(old = TRUE), pathOld)
+
+  expect_true(.profileInit(pathProject))
+  expect_false(file.exists(pathOld))
+
+  timer <- .profileStart(
+    level = "major",
+    major = "initial_gating",
+    operation = "test_major",
+    pathProject = pathProject
+  )
+  expect_false(is.null(timer))
+  .profileStop(timer)
+
+  rawFiles <- list.files(
+    file.path(pathProject, "profile", "raw"),
+    pattern = "\\.rds$",
+    full.names = TRUE
+  )
+  expect_length(rawFiles, 1L)
+  raw <- readRDS(rawFiles[[1L]])
+  expect_equal(raw$operation, "test_major")
+  expect_equal(raw$status, "completed")
+  expect_true(is.numeric(raw$elapsed_sec))
+
+  .profileFinishRun(pathProject)
+  expect_true(file.exists(file.path(pathProject, "profile", "profile.rds")))
+  expect_true(file.exists(file.path(pathProject, "profile", "profile.csv")))
+  expect_true(dir.exists(file.path(pathProject, "profile", "raw")))
+})
+
+test_that("profiling records explicit hierarchy and sample context", {
+  withr::local_envvar(c(STIMGATE_DEBUG = "yes"))
+  .profileStateReset()
+  pathProject <- tempfile("stimgate-profile-hierarchy-")
+  expect_true(.profileInit(pathProject))
+
+  .profileWithContext(
+    .profileTime(
+      .profileTime(
+        1 + 1,
+        level = "sample_detail",
+        major = "initial_gating",
+        minor = "local_fdr",
+        operation = "marginal_filtering",
+        pathProject = pathProject
+      ),
+      level = "sample",
+      major = "initial_gating",
+      minor = "local_fdr",
+      operation = "sample_initial_gating",
+      pathProject = pathProject
+    ),
+    marker = "IL2",
+    channel = "IL2-A",
+    batch = "participant_17",
+    sample = "104",
+    stage = "init"
+  )
+
+  profileTbl <- .profileFinishRun(pathProject)
+  sampleRow <- profileTbl[
+    profileTbl$operation == "sample_initial_gating",
+    ,
+    drop = FALSE
+  ]
+  detailRow <- profileTbl[
+    profileTbl$operation == "marginal_filtering",
+    ,
+    drop = FALSE
+  ]
+  runRow <- profileTbl[profileTbl$operation == "gateStim", , drop = FALSE]
+
+  expect_equal(nrow(sampleRow), 1L)
+  expect_equal(nrow(detailRow), 1L)
+  expect_equal(nrow(runRow), 1L)
+  expect_equal(sampleRow$marker, "IL2")
+  expect_equal(sampleRow$channel, "IL2-A")
+  expect_equal(sampleRow$batch, "participant_17")
+  expect_equal(sampleRow$sample, "104")
+  expect_equal(sampleRow$stage, "init")
+  expect_equal(detailRow$parent_id, sampleRow$record_id)
+  expect_equal(sampleRow$parent_id, runRow$record_id)
+  expect_gt(detailRow$depth, sampleRow$depth)
+})
+
+test_that("profiling instrumentation preserves wrapped function arguments", {
+  expect_identical(names(formals(.gateInit)), names(formals(.profileOriginalGateInit)))
+  expect_identical(
+    names(formals(.gateCytPos)),
+    names(formals(.profileOriginalGateCytPos))
+  )
+  expect_identical(
+    names(formals(.gateStats)),
+    names(formals(.profileOriginalGateStats))
+  )
+  expect_identical(
+    names(formals(.gateChnl)),
+    names(formals(.profileOriginalGateChnl))
+  )
+  expect_identical(
+    names(formals(.gateBatch)),
+    names(formals(.profileOriginalGateBatch))
+  )
+  expect_identical(
+    names(formals(.getCpUnsLocCondition)),
+    names(formals(.profileOriginalGetCpUnsLocCondition))
+  )
+  expect_identical(
+    names(formals(.getCpUnsLocGetProb)),
+    names(formals(.profileOriginalGetCpUnsLocGetProb))
+  )
+  expect_identical(
+    names(formals(.getCpUnsLocGetCp)),
+    names(formals(.profileOriginalGetCpUnsLocGetCp))
+  )
+})


### PR DESCRIPTION
## Summary

Adds structured timing profiles whenever `STIMGATE_DEBUG` is enabled, without adding a new public argument or profiling environment variable.

- resets `pathProject/profile/` at the start of each debug `gateStim()` run
- writes each completed timing record immediately to `profile/raw/` as a small RDS file
- collates completed records at the end of a successful run into `profile/profile.rds` and `profile/profile.csv`
- records explicit hierarchy through `record_id`, `parent_id`, `depth`, `level`, `major`, `minor` and `operation`, together with marker/channel/batch/sample/stage context
- profiles the broad `initial_gating`, `cytokine_positive_gating` and `final_statistics` stages
- goes deeper only for initial gating: marker, batch, local-FDR initial gating, cross-sample clustering and per-sample local-FDR work
- within each initial-gating sample, selectively records the probability model, density/bandwidth calculation, antimode work when it runs, filtering/threshold work and marginal filtering
- retains completed raw records if a run fails partway through; profiling I/O failures are diagnostic only and do not fail gating

The whole-run timer starts at `gateStim()`'s first project write, after input verification and before channel setup/gating. Nested elapsed times are actual wall-clock timings and are not intended to sum to their parent duration.

## Implementation notes

The profiling helpers live in `R/profile.R`. A late-loaded instrumentation file wraps selected internal workflow boundaries while preserving their existing signatures, keeping timing code out of the statistical implementation. `AGENTS.md` documents the profiling convention and the intentionally selective first-pass scope.

## Tests

Adds focused package tests for:

- profiling being off outside debug mode
- wiping the previous profile directory for a new debug run
- incremental raw-record persistence
- final RDS/CSV collation
- hierarchy and per-sample context
- preservation of wrapped function arguments

I could not execute the R test suite in this environment, so CI should be treated as the execution check for this PR.