### PR TITLE
Refactor ACS CyTOF gating into tester and population runs

### DIFF
--- a/analysis/9-real-compare-acs-cytof.qmd
+++ b/analysis/9-real-compare-acs-cytof.qmd
@@ -8,6 +8,8 @@ params:
   run_preprocessing: true
   run_methods: true
   run_plots: false
+  tester_n_sample: 20
+  n_workers: 2
 ---
 
 ```{r}
@@ -28,45 +30,55 @@ scripts_r_dir <- file.path(root_dir, "scripts", "r")
 source(file.path(scripts_r_dir, "analysis-runtime.R"))
 source(file.path(scripts_r_dir, "acs_cytof-helper.R"))
 source(file.path(scripts_r_dir, "acs_cytof-preprocess.R"))
-
-pop_vec <- c("tcrgd", "cd4", "cd8", "nk", "pre_nk", "tcrgd")
+source(file.path(scripts_r_dir, "acs_cytof-gate.R"))
 
 run_preprocessing <- .as_flag(.get_qmd_param_env(
   "run_preprocessing",
   "RUN_PREPROCESSING",
   FALSE
 ))
-run_preprocessing_vec_by_pop <- c(
-  tcrgd = NULL %||% run_preprocessing,
-  cd4 = NULL %||%  run_preprocessing,
-  cd8 = NULL %||% run_preprocessing,
-  nk = NULL %||% run_preprocessing,
-  pre_nk = NULL %||% run_preprocessing
-)
 run_methods <- .as_flag(.get_qmd_param_env(
   "run_methods",
   "RUN_METHODS",
   TRUE
 ))
-run_methods_vec_by_pop <- c(
-  tcrgd = NULL %||% run_methods,
-  cd4 = NULL %||%  run_methods,
-  cd8 = NULL %||% run_methods,
-  nk = NULL %||% run_methods,
-  pre_nk = NULL %||% run_methods
-)
 run_plots <- .as_flag(.get_qmd_param_env(
   "run_plots",
   "RUN_PLOTS",
   TRUE
 ))
-run_plots_vec_by_pop <- c(
-  tcrgd = NULL %||% run_plots,
-  cd4 = NULL %||%  run_plots,
-  cd8 = NULL %||% run_plots,
-  nk = NULL %||% run_plots,
-  pre_nk = NULL %||% run_plots
+tester_n_sample <- as.integer(.get_qmd_param_env(
+  "tester_n_sample",
+  "ACS_TESTER_N_SAMPLE",
+  20L
+))
+n_workers <- as.integer(.get_qmd_param_env(
+  "n_workers",
+  "ACS_N_WORKERS",
+  2L
+))
+
+if (is.na(n_workers) || n_workers < 1L) {
+  stop("n_workers must be at least one.")
+}
+.acsCytofBatchList(tester_n_sample)
+
+# Population-level controls belong here. These named vectors make it easy to
+# rerun only selected stages for one population without changing the helper.
+pop_vec <- c("tcrgd", "cd4", "cd8", "nk", "nk_pre", "b")
+run_preprocessing_vec_by_pop <- stats::setNames(
+  rep(run_preprocessing, length(pop_vec)),
+  pop_vec
 )
+run_methods_vec_by_pop <- stats::setNames(
+  rep(run_methods, length(pop_vec)),
+  pop_vec
+)
+run_plots_vec_by_pop <- stats::setNames(
+  rep(run_plots, length(pop_vec)),
+  pop_vec
+)
+bias_uns_vec_by_pop <- stats::setNames(rep(0.15, length(pop_vec)), pop_vec)
 
 desc_path <- file.path(root_dir, "DESCRIPTION")
 if (
@@ -89,17 +101,25 @@ background-subtracted response frequencies with Tailgate and F-beta.
 
 ## Gating
 
-### Common settings
+The TCRgd population is first run on a limited set of complete five-sample
+batches. If that tester completes successfully, the same preprocessing and
+StimGate flow is applied to every population configured in `pop_vec`.
 
-Here we specify settings common across all the populations gated.
+The reusable helper fixes the settings that are shared by these runs, including
+the six cytokine channels, `bwMtd = "hpi1"`, debug profiling and the required
+`gateCombn = "min"`. The population, stage controls, tester sample limit and
+`biasUns` remain visible here because they are the settings most likely to vary.
+
+### Common paths
 
 ```{r}
+#| label: settings-common-gating-paths
 path_fcs_base <- projr::projr_path_get(
   "raw-data",
   "comparison_data", "acscytof", "fcs"
 )
 if (!dir.exists(path_fcs_base)) {
-  stop("Path to fcs files does not exist: ", path_fcs_base)
+  stop("Path to FCS files does not exist: ", path_fcs_base)
 }
 path_gs_base <- projr::projr_path_get(
   "cache",
@@ -113,336 +133,84 @@ path_scratch_base <- projr::projr_path_get(
 )
 ```
 
+### TCRgd tester
+
+The tester uses only the first `tester_n_sample` files, which must comprise
+complete batches of one unstimulated and four stimulated samples. Its cached
+GatingSet and StimGate project are kept under a separate `tester/tcrgd`
+subdirectory, so they cannot overwrite the full TCRgd run.
+
 ```{r}
-#| label: settings-common-gatings
-chnl_vec <- c("Ho165Di", "Gd158Di", "Nd146Di", "Dy164Di", "Gd156Di", "Nd150Di")
-
-# StimGate settings. gateCombn is intentionally explicit.
-stimgate_gate_combn <- "min"
-stimgate_bw_mtd <- "hpi1"
-stimgate_bw_ncell_max <- 1e4
-stimgate_bw_fallback <- "auto"
-stimgate_bw_min <- "none"
-stimgate_bw_max <- "none"
-stimgate_bias_uns <- NULL
-stimgate_min_cell <- 100
-tol_clust <- NULL
-calc_cyt_pos_gates <- TRUE
-
-# Comparator settings, matching the corrected analyses 7 and 8 semantics.
-fbeta_beta <- 0.8
-fbeta_theta <- 2
-fbeta_width <- 10
-path_fbeta <- projr::projr_path_get(
-  "project",
-  "scripts",
-  "python",
-  "fbeta.py"
+#| label: run-tcrgd-tester
+#| results: hide
+tcrgd_tester <- .acsCytofRunPopulation(
+  pop = "tcrgd",
+  pathFcsBase = path_fcs_base,
+  pathGsBase = path_gs_base,
+  pathScratchBase = path_scratch_base,
+  runPreprocessing = run_preprocessing,
+  runMethods = run_methods,
+  runPlots = run_plots,
+  nSample = tester_n_sample,
+  biasUns = bias_uns_vec_by_pop[["tcrgd"]],
+  outputGroup = "tester"
 )
-
-tailgate_adjust <- 1
-tailgate_method <- "firstDeriv"
-tailgate_tol <- 1e-2
-tailgate_auto_tol <- TRUE
 ```
 
-### TCRgd
+### Across populations, in parallel
+
+Each population writes to its own cached GatingSet and scratch directory. The
+number of concurrent population runs defaults to two and can be changed with
+the `n_workers` parameter or `ACS_N_WORKERS` environment variable.
 
 ```{r}
-# directories
-path_fcs_tcrgd <- file.path(path_fcs_base, "tcrgd")
-path_gs_tcrgd <- file.path(path_gs_base, "tcrgd")
-path_scratch_tcrgd <- file.path(path_scratch_base, "tcrgd")
-if (!dir.exists(path_scratch_tcrgd)) {
-  dir.create(path_scratch_tcrgd, recursive = TRUE, showWarnings = FALSE)
-}
-path_stimgate_tcrgd <- file.path(path_scratch_tcrgd, "stimgate")
-# gating settings
-bias_uns_tcrgd <- 0.15
-```
-
-#### Pre-processing
-
-##### Create GatingSet
-
-```{r}
-#| label: create-gatingset-tcrgd
+#| label: run-all-populations
 #| results: hide
-if (isTRUE(run_preprocessing)) {
-  # ensure fcs directory exists
-  if (!dir.exists(path_fcs_tcrgd)) {
-    stop("Path to TCRgd FCS files does not exist: ", path_fcs_tcrgd)
-  }
-  # ensure that there are many fcs files in there
-  fcs_files_tcrgd <- list.files(
-    path_fcs_tcrgd,
-    pattern = "\\.fcs$",
-    recursive = TRUE,
-    full.names = TRUE,
-    ignore.case = TRUE
-  )
-  if (length(fcs_files_tcrgd) < 10L) {
-    stop(
-      "Expected at least 10 TCRgd FCS files in the directory, but found
-  only ", length(fcs_files_tcrgd), "."
+n_workers_use <- min(n_workers, length(pop_vec))
+old_plan <- future::plan()
+
+population_runs <- tryCatch(
+  {
+    if (n_workers_use > 1L) {
+      future::plan(future::multisession, workers = n_workers_use)
+    } else {
+      future::plan(future::sequential)
+    }
+
+    furrr::future_map(
+      pop_vec,
+      function(pop) {
+        .acsCytofRunPopulation(
+          pop = pop,
+          pathFcsBase = path_fcs_base,
+          pathGsBase = path_gs_base,
+          pathScratchBase = path_scratch_base,
+          runPreprocessing = run_preprocessing_vec_by_pop[[pop]],
+          runMethods = run_methods_vec_by_pop[[pop]],
+          runPlots = run_plots_vec_by_pop[[pop]],
+          biasUns = bias_uns_vec_by_pop[[pop]]
+        )
+      },
+      .options = furrr::furrr_options(seed = TRUE)
     )
-  }
-  # ensure that the gating set directory exists and is empty
-  if (dir.exists(path_gs_tcrgd)) {
-    unlink(path_gs_tcrgd, recursive = TRUE)
-  }
-  dir.create(path_gs_tcrgd, recursive = TRUE, showWarnings = FALSE)
-  # create the gatingset
-  create_gatingset(
-    path_fcs = path_fcs_tcrgd,
-    path_gs = path_gs_tcrgd # ,
-    # n_sample = 20
-  )
-
-  # plot the gatingset to check transformation
-  # is appropriate
-  # create the scratch directory
-  path_check_tcrgd <- file.path(path_scratch_tcrgd, "gatingset")
-  if (!dir.exists(path_check_tcrgd)) {
-    dir.create(path_check_tcrgd, recursive = TRUE, showWarnings = FALSE)
-  }
-  plot_gatingset_check(
-    path_gs = path_gs_tcrgd,
-    path_plot_dir = path_check_tcrgd
-  )
-  # okay, looking here, we clearly need to use the transformation,
-  # as e.g. the DNA markers are just vertical bars otherwise
-  # and I know from preprocessing that they should not be so.
-}
+  },
+  finally = future::plan(old_plan)
+)
+names(population_runs) <- pop_vec
 ```
 
-#### Gate
+## Tailgate and F-beta
 
-##### StimGate
+The reusable run above covers the currently working ACS preprocessing and
+StimGate path. Tailgate and F-beta will be added to the same population helper
+once their ACS method grid and result-cache contract have been completed.
 
-```{r}
-#| label: gate-stimgate-tcrgd
-if (run_methods) {
-  # ensure a clean stimgate run
-  if (dir.exists(path_stimgate_tcrgd)) {
-    unlink(path_stimgate_tcrgd, recursive = TRUE)
-  }
-  dir.create(path_stimgate_tcrgd, recursive = TRUE, showWarnings = FALSE)
+## Compare methods with the ACS reference counts
 
-  # load gatingset
-  gs_tcrgd <- flowWorkspace::load_gs(path_gs_tcrgd)
+## Output tables and figures
 
-  # create a batch_list object,
-  # which for each element has five indices,
-  # the first of which specifies unstim.
-  # the elements covered go from
-  # 1 to the length of gs_tcrgd.
-  # and every fifth element in gs_tcrgd is an unstim sample.
-  # but its index must go FIRST in batch_list
-  # (and all the stims come afterwards)
-  batch_list_tcrgd <- lapply(seq(1, length(gs_tcrgd), by = 5), function(i) {
-    c(i, seq(i + 1, min(i + 4, length(gs_tcrgd))))
-  })
+### Save analysis tables
 
-  Sys.setenv("STIMGATE_DEBUG" = "TRUE")
+### Estimated versus reference response frequency
 
-  invisible(stimgate::gateStim(
-    pathProject = path_stimgate_tcrgd,
-    .data = gs_tcrgd,
-    popGate = "root",
-    batchList = batch_list_tcrgd,
-    chnl = chnl_vec,
-    biasUns = bias_uns_tcrgd,
-    bwMtd = stimgate_bw_mtd,
-    bwNcellMax = stimgate_bw_ncell_max,
-    bwFallback = stimgate_bw_fallback,
-    bwMin = stimgate_bw_min,
-    bwMax = stimgate_bw_max,
-    minCell = stimgate_min_cell,
-    gateCombn = stimgate_gate_combn,
-    tolClust = tol_clust,
-    calcCytPosGates = calc_cyt_pos_gates
-  ))
-
-  p <- plotStim(
-    ind = 2L,
-    .data = gs_tcrgd,
-    pathProject = path_stimgate_tcrgd,
-    pop = "root",
-    chnl = c("Ho165Di", "Nd146Di"),
-  )
-
-  path_p_stimgate_check_tcrgd <- projr::projr_path_get(
-    "cache",
-    "acs_cytof",
-    "scratch",
-    "tcrgd",
-    "stimgate_check.pdf"
-  )
-  ggsave(
-    path_p_stimgate_check_tcrgd,
-    p,
-    width = 18,
-    height = 16,
-    units = "cm"
-  )
-}
-```
-
-#### Tailgate
-
-```{r}
-#| label: run-tailgate-tcrgd
-#| results: hide
-#| eval: false
-path_tailgate_results <- file.path(acs_cache_dir, "tailgate_results.rds")
-
-if (isTRUE(run_methods)) {
-  tailgate_results <- purrr::pmap_dfr(
-    method_grid,
-    function(batch,
-             indUns,
-             indStim,
-             sampleUns,
-             sampleStim,
-             conditionStim,
-             channel,
-             marker) {
-      x_stim <- .acs_get_expr(gs_acs, indStim, channel, acs_pop_gate)
-      x_uns <- .acs_get_expr(gs_acs, indUns, channel, acs_pop_gate)
-
-      threshold_obj <- tryCatch(
-        .simCompareTailgateThreshold(
-          x = x_stim,
-          adjust = tailgate_adjust,
-          method = tailgate_method,
-          tol = tailgate_tol,
-          autoTol = tailgate_auto_tol,
-          strict = FALSE
-        ),
-        error = function(e) {
-          list(
-            threshold = NA_real_,
-            thresholdMetric = NA_real_,
-            thresholdOrigin = paste0("error: ", e$message)
-          )
-        }
-      )
-
-      est <- .simCompareEstimateFromThreshold(
-        xStim = x_stim,
-        xUns = x_uns,
-        threshold = threshold_obj$threshold,
-        fallbackHighValue = TRUE
-      )
-
-      tibble::as_tibble(est) |>
-        dplyr::transmute(
-          batch = batch,
-          indUns = indUns,
-          indStim = indStim,
-          sampleUns = sampleUns,
-          sampleStim = sampleStim,
-          conditionStim = conditionStim,
-          channel = channel,
-          marker = marker,
-          method = "tailgate",
-          threshold = .data$threshold,
-          thresholdOrigin = threshold_obj$thresholdOrigin,
-          thresholdMetric = threshold_obj$thresholdMetric,
-          thresholdFallbackUsed = .data$thresholdFallbackUsed,
-          nCellStim = .data$nCellStim,
-          nCellUns = .data$nCellUns,
-          nPosStim = .data$nPosStim,
-          nPosUns = .data$nPosUns,
-          propStim = .data$propStim,
-          propUns = .data$propUns,
-          propRespEst = .data$propRespEst
-        )
-    }
-  )
-  saveRDS(tailgate_results, path_tailgate_results)
-} else {
-  tailgate_results <- readRDS(path_tailgate_results)
-}
-```
-
-#### F-beta
-
-```{r}
-#| label: run-fbeta-tcrgd
-#| results: hide
-#| eval: false
-path_fbeta_results <- file.path(acs_cache_dir, "fbeta_results.rds")
-
-if (isTRUE(run_methods)) {
-  fbeta_results <- purrr::pmap_dfr(
-    method_grid,
-    function(batch,
-             indUns,
-             indStim,
-             sampleUns,
-             sampleStim,
-             conditionStim,
-             channel,
-             marker) {
-      x_stim <- .acs_get_expr(gs_acs, indStim, channel, acs_pop_gate)
-      x_uns <- .acs_get_expr(gs_acs, indUns, channel, acs_pop_gate)
-
-      threshold_obj <- tryCatch(
-        .simCompareFbetaThreshold(
-          xUns = x_uns,
-          xStim = x_stim,
-          pathFbeta = path_fbeta,
-          beta = fbeta_beta,
-          theta = fbeta_theta,
-          width = fbeta_width
-        ),
-        error = function(e) {
-          list(
-            threshold = NA_real_,
-            thresholdMetric = NA_real_,
-            thresholdOrigin = paste0("error: ", e$message)
-          )
-        }
-      )
-
-      est <- .simCompareEstimateFromThreshold(
-        xStim = x_stim,
-        xUns = x_uns,
-        threshold = threshold_obj$threshold,
-        fallbackHighValue = TRUE
-      )
-
-      tibble::as_tibble(est) |>
-        dplyr::transmute(
-          batch = batch,
-          indUns = indUns,
-          indStim = indStim,
-          sampleUns = sampleUns,
-          sampleStim = sampleStim,
-          conditionStim = conditionStim,
-          channel = channel,
-          marker = marker,
-          method = "fbeta",
-          threshold = .data$threshold,
-          thresholdOrigin = threshold_obj$thresholdOrigin,
-          thresholdMetric = threshold_obj$thresholdMetric,
-          thresholdFallbackUsed = .data$thresholdFallbackUsed,
-          nCellStim = .data$nCellStim,
-          nCellUns = .data$nCellUns,
-          nPosStim = .data$nPosStim,
-          nPosUns = .data$nPosUns,
-          propStim = .data$propStim,
-          propUns = .data$propUns,
-          propRespEst = .data$propRespEst
-        )
-    }
-  )
-  saveRDS(fbeta_results, path_fbeta_results)
-} else {
-  fbeta_results <- readRDS(path_fbeta_results)
-}
-```
-
-### Across pops, in parallel
+### Relative error by method

--- a/analysis/tests/testthat/test-acs-cytof-gate.R
+++ b/analysis/tests/testthat/test-acs-cytof-gate.R
@@ -1,0 +1,80 @@
+root_dir <- normalizePath(file.path(testthat::test_path(), "../../.."), mustWork = TRUE)
+script_gate <- file.path(root_dir, "scripts", "r", "acs_cytof-gate.R")
+qmd_path <- file.path(root_dir, "analysis", "9-real-compare-acs-cytof.qmd")
+
+.load_acs_gate_env <- function() {
+  env <- new.env(parent = getNamespace("stimgate"))
+  source(script_gate, local = env)
+  env
+}
+
+test_that("ACS CyTOF batches contain one unstimulated and four stimulated samples", {
+  env <- .load_acs_gate_env()
+
+  expect_equal(
+    env$.acsCytofBatchList(20L),
+    list(1:5, 6:10, 11:15, 16:20)
+  )
+  expect_error(env$.acsCytofBatchList(19L), "multiple of five")
+  expect_error(env$.acsCytofBatchList(0L), "at least 5")
+})
+
+test_that("the TCRgd tester and full population use separate output paths", {
+  env <- .load_acs_gate_env()
+
+  full <- env$.acsCytofPopulationPaths(
+    pop = "tcrgd",
+    pathFcsBase = "raw",
+    pathGsBase = "gs",
+    pathScratchBase = "scratch"
+  )
+  tester <- env$.acsCytofPopulationPaths(
+    pop = "tcrgd",
+    pathFcsBase = "raw",
+    pathGsBase = "gs",
+    pathScratchBase = "scratch",
+    outputGroup = "tester"
+  )
+
+  expect_equal(full$fcs, tester$fcs)
+  expect_equal(full$gs, file.path("gs", "tcrgd"))
+  expect_equal(tester$gs, file.path("gs", "tester", "tcrgd"))
+  expect_equal(
+    tester$stimgate,
+    file.path("scratch", "tester", "tcrgd", "stimgate")
+  )
+  expect_false(identical(full$stimgate, tester$stimgate))
+})
+
+test_that("the reusable population runner preserves the ACS StimGate contract", {
+  env <- .load_acs_gate_env()
+  runner_formals <- names(formals(env$.acsCytofRunPopulation))
+  runner_body <- paste(deparse(body(env$.acsCytofRunPopulation)), collapse = "\n")
+
+  expect_true(all(c(
+    "pop", "runPreprocessing", "runMethods", "runPlots",
+    "nSample", "biasUns", "outputGroup"
+  ) %in% runner_formals))
+  expect_true(grepl('gateCombn = "min"', runner_body, fixed = TRUE))
+  expect_true(grepl('bwMtd = "hpi1"', runner_body, fixed = TRUE))
+  expect_true(grepl("calcCytPosGates = TRUE", runner_body, fixed = TRUE))
+})
+
+test_that("analysis 9 uses one runner for the tester and configured populations", {
+  content <- paste(readLines(qmd_path, warn = FALSE), collapse = "\n")
+
+  expect_true(grepl(
+    'pop_vec <- c("tcrgd", "cd4", "cd8", "nk", "nk_pre", "b")',
+    content,
+    fixed = TRUE
+  ))
+  expect_gte(
+    lengths(regmatches(
+      content,
+      gregexpr(".acsCytofRunPopulation(", content, fixed = TRUE)
+    )),
+    2L
+  )
+  expect_true(grepl('outputGroup = "tester"', content, fixed = TRUE))
+  expect_true(grepl("furrr::future_map", content, fixed = TRUE))
+})

--- a/analysis/tests/testthat/test-helper-sourcing.R
+++ b/analysis/tests/testthat/test-helper-sourcing.R
@@ -8,6 +8,9 @@ script_bw_io <- file.path(root_dir, "scripts", "r", "sim-bandwidth-analysis-io.R
 script_bw_plot <- file.path(root_dir, "scripts", "r", "sim-bandwidth-analysis-plot.R")
 script_comp <- file.path(root_dir, "scripts", "r", "sim-compare-freq_bs.R")
 script_trans <- file.path(root_dir, "scripts", "r", "sim-trans.R")
+script_acs_helper <- file.path(root_dir, "scripts", "r", "acs_cytof-helper.R")
+script_acs_preprocess <- file.path(root_dir, "scripts", "r", "acs_cytof-preprocess.R")
+script_acs_gate <- file.path(root_dir, "scripts", "r", "acs_cytof-gate.R")
 
 test_that("scripts/r helpers source without error in dependency order", {
   for (f in c(
@@ -18,7 +21,10 @@ test_that("scripts/r helpers source without error in dependency order", {
     script_bw_io,
     script_bw_plot,
     script_comp,
-    script_trans
+    script_trans,
+    script_acs_helper,
+    script_acs_preprocess,
+    script_acs_gate
   )) {
     if (!file.exists(f)) {
       stop("Expected analysis helper not found: ", f)
@@ -34,6 +40,9 @@ test_that("scripts/r helpers source without error in dependency order", {
   expect_no_error(source(script_bw_plot, local = env))
   expect_no_error(source(script_comp, local = env))
   expect_no_error(source(script_trans, local = env))
+  expect_no_error(source(script_acs_helper, local = env))
+  expect_no_error(source(script_acs_preprocess, local = env))
+  expect_no_error(source(script_acs_gate, local = env))
 })
 
 test_that("QMD analysis scripts do not call scripts/r helpers via stimgate:::", {

--- a/scripts/r/acs_cytof-gate.R
+++ b/scripts/r/acs_cytof-gate.R
@@ -1,0 +1,271 @@
+.acsCytofPopulationPaths <- function(
+  pop,
+  pathFcsBase,
+  pathGsBase,
+  pathScratchBase,
+  outputGroup = NULL
+) {
+  if (!is.character(pop) || length(pop) != 1L || !nzchar(pop)) {
+    stop("pop must be one non-empty character value.")
+  }
+  if (!is.null(outputGroup) &&
+    (!is.character(outputGroup) ||
+      length(outputGroup) != 1L ||
+      !nzchar(outputGroup))) {
+    stop("outputGroup must be NULL or one non-empty character value.")
+  }
+
+  outputParts <- if (is.null(outputGroup)) pop else c(outputGroup, pop)
+  pathGs <- do.call(file.path, as.list(c(pathGsBase, outputParts)))
+  pathScratch <- do.call(file.path, as.list(c(pathScratchBase, outputParts)))
+
+  list(
+    fcs = file.path(pathFcsBase, pop),
+    gs = pathGs,
+    scratch = pathScratch,
+    gsCheck = file.path(pathScratch, "gatingset"),
+    stimgate = file.path(pathScratch, "stimgate"),
+    stimgateCheck = file.path(pathScratch, "stimgate_check.pdf")
+  )
+}
+
+.acsCytofBatchList <- function(nSample) {
+  if (!is.numeric(nSample) ||
+    length(nSample) != 1L ||
+    is.na(nSample) ||
+    !is.finite(nSample) ||
+    nSample != as.integer(nSample) ||
+    nSample < 5L) {
+    stop("nSample must be one integer of at least 5.")
+  }
+
+  nSample <- as.integer(nSample)
+  nPerBatch <- 5L
+  if (nSample %% nPerBatch != 0L) {
+    stop(
+      "The ACS CyTOF sample count must be a multiple of five so that ",
+      "every batch contains one unstimulated and four stimulated samples."
+    )
+  }
+
+  lapply(seq.int(1L, nSample, by = nPerBatch), function(indUns) {
+    seq.int(indUns, length.out = nPerBatch)
+  })
+}
+
+.acsCytofFcsFiles <- function(pathFcs) {
+  if (!dir.exists(pathFcs)) {
+    stop("ACS CyTOF FCS directory not found at: ", pathFcs)
+  }
+
+  fcsFiles <- list.files(
+    pathFcs,
+    pattern = "\\.fcs$",
+    recursive = TRUE,
+    full.names = TRUE,
+    ignore.case = TRUE
+  )
+  if (length(fcsFiles) < 10L) {
+    stop(
+      "Expected at least 10 ACS CyTOF FCS files in ", pathFcs,
+      ", but found only ", length(fcsFiles), "."
+    )
+  }
+
+  sort(fcsFiles)
+}
+
+.acsCytofPreprocessPopulation <- function(paths, nSample = NULL, runPlots = TRUE) {
+  fcsFiles <- .acsCytofFcsFiles(paths$fcs)
+  if (!is.null(nSample)) {
+    .acsCytofBatchList(nSample)
+    if (nSample > length(fcsFiles)) {
+      stop(
+        "Requested ", nSample, " tester samples, but only ",
+        length(fcsFiles), " FCS files are available."
+      )
+    }
+  }
+
+  create_gatingset(
+    path_fcs = paths$fcs,
+    path_gs = paths$gs,
+    n_sample = nSample
+  )
+
+  if (isTRUE(runPlots)) {
+    plot_gatingset_check(
+      path_gs = paths$gs,
+      path_plot_dir = paths$gsCheck
+    )
+  }
+
+  invisible(paths$gs)
+}
+
+.acsCytofEnsureCurrentCheckout <- function(pathRoot = NULL) {
+  if (is.null(pathRoot) || !nzchar(pathRoot)) {
+    if (requireNamespace("projr", quietly = TRUE)) {
+      pathRoot <- tryCatch(
+        projr::projr_path_get("project"),
+        error = function(e) normalizePath(".", winslash = "/", mustWork = FALSE)
+      )
+    } else {
+      pathRoot <- normalizePath(".", winslash = "/", mustWork = FALSE)
+    }
+  }
+  pathRoot <- normalizePath(pathRoot, winslash = "/", mustWork = FALSE)
+
+  if (requireNamespace("stimgate", quietly = TRUE)) {
+    ns <- tryCatch(asNamespace("stimgate"), error = function(e) NULL)
+    if (!is.null(ns)) {
+      nsPath <- normalizePath(
+        getNamespaceInfo(ns, "path"),
+        winslash = "/",
+        mustWork = FALSE
+      )
+      if (isTRUE(identical(nsPath, pathRoot))) {
+        return(invisible(TRUE))
+      }
+    }
+  }
+
+  if (requireNamespace("pkgload", quietly = TRUE)) {
+    suppressMessages(pkgload::load_all(pathRoot, quiet = TRUE))
+  } else if (requireNamespace("devtools", quietly = TRUE)) {
+    suppressMessages(devtools::load_all(pathRoot, quiet = TRUE))
+  } else {
+    stop(
+      "Neither pkgload nor devtools is available to load the current ",
+      "StimGate checkout."
+    )
+  }
+
+  invisible(TRUE)
+}
+
+.acsCytofSetDebug <- function() {
+  oldDebug <- Sys.getenv("STIMGATE_DEBUG", unset = NA_character_)
+  Sys.setenv(STIMGATE_DEBUG = "TRUE")
+
+  function() {
+    if (is.na(oldDebug)) {
+      Sys.unsetenv("STIMGATE_DEBUG")
+    } else {
+      Sys.setenv(STIMGATE_DEBUG = oldDebug)
+    }
+  }
+}
+
+.acsCytofRunPopulation <- function(
+  pop,
+  pathFcsBase,
+  pathGsBase,
+  pathScratchBase,
+  runPreprocessing,
+  runMethods,
+  runPlots,
+  nSample = NULL,
+  biasUns = 0.15,
+  outputGroup = NULL
+) {
+  paths <- .acsCytofPopulationPaths(
+    pop = pop,
+    pathFcsBase = pathFcsBase,
+    pathGsBase = pathGsBase,
+    pathScratchBase = pathScratchBase,
+    outputGroup = outputGroup
+  )
+
+  if (isTRUE(runPreprocessing)) {
+    .acsCytofPreprocessPopulation(
+      paths = paths,
+      nSample = nSample,
+      runPlots = runPlots
+    )
+  }
+
+  if (!isTRUE(runMethods) && !isTRUE(runPlots)) {
+    return(invisible(list(pop = pop, paths = paths)))
+  }
+  if (!dir.exists(paths$gs)) {
+    stop(
+      "Cached ACS CyTOF GatingSet not found for '", pop, "' at: ",
+      paths$gs, ". Run preprocessing for this population first."
+    )
+  }
+
+  .acsCytofEnsureCurrentCheckout()
+  gs <- flowWorkspace::load_gs(paths$gs)
+  nSampleActual <- length(gs)
+  if (!is.null(nSample) && nSampleActual != nSample) {
+    stop(
+      "Cached tester GatingSet for '", pop, "' contains ", nSampleActual,
+      " samples; expected ", nSample, ". Re-run tester preprocessing."
+    )
+  }
+  batchList <- .acsCytofBatchList(nSampleActual)
+
+  if (isTRUE(runMethods)) {
+    if (dir.exists(paths$stimgate)) {
+      unlink(paths$stimgate, recursive = TRUE)
+    }
+    dir.create(paths$stimgate, recursive = TRUE, showWarnings = FALSE)
+
+    restoreDebug <- .acsCytofSetDebug()
+    on.exit(restoreDebug(), add = TRUE)
+
+    invisible(stimgate::gateStim(
+      pathProject = paths$stimgate,
+      .data = gs,
+      popGate = "root",
+      batchList = batchList,
+      chnl = c(
+        "Ho165Di", "Gd158Di", "Nd146Di",
+        "Dy164Di", "Gd156Di", "Nd150Di"
+      ),
+      biasUns = biasUns,
+      bwMtd = "hpi1",
+      bwNcellMax = 1e4,
+      bwFallback = "auto",
+      bwMin = "none",
+      bwMax = "none",
+      minCell = 100,
+      gateCombn = "min",
+      tolClust = NULL,
+      calcCytPosGates = TRUE
+    ))
+  }
+
+  if (isTRUE(runPlots)) {
+    if (!dir.exists(paths$stimgate)) {
+      stop(
+        "StimGate output not found for '", pop, "' at: ", paths$stimgate,
+        ". Run the methods for this population first."
+      )
+    }
+
+    p <- stimgate::plotStim(
+      ind = 2L,
+      .data = gs,
+      pathProject = paths$stimgate,
+      pop = "root",
+      chnl = c("Ho165Di", "Nd146Di")
+    )
+    dir.create(dirname(paths$stimgateCheck), recursive = TRUE, showWarnings = FALSE)
+    ggplot2::ggsave(
+      filename = paths$stimgateCheck,
+      plot = p,
+      width = 18,
+      height = 16,
+      units = "cm"
+    )
+  }
+
+  invisible(list(
+    pop = pop,
+    nSample = nSampleActual,
+    batchList = batchList,
+    paths = paths
+  ))
+}

--- a/scripts/r/acs_cytof-preprocess.R
+++ b/scripts/r/acs_cytof-preprocess.R
@@ -4,25 +4,40 @@ create_gatingset <- function(
   n_sample = NULL,
   ind_sample = NULL
 ) {
-  stopifnot(length(list.files(path_fcs, pattern = "fcs$")) > 0)
-  if (is.null(n_sample) && is.null(ind_sample)) {
-    cs <- flowWorkspace::load_cytoset_from_fcs(
-      path = path_fcs,
-      pattern = "fcs$"
-    )
-  } else {
-    fcs_vec <- list.files(
-      path_fcs,
-      pattern = "fcs$",
-      full.names = TRUE
-    )
-    if (!is.null(ind_sample)) {
-      fcs_vec <- fcs_vec[ind_sample]
-    } else {
-      fcs_vec <- fcs_vec[seq_len(n_sample)]
-    }
-    cs <- flowWorkspace::load_cytoset_from_fcs(fcs_vec)
+  if (!is.null(n_sample) && !is.null(ind_sample)) {
+    stop("Specify only one of n_sample and ind_sample.")
   }
+
+  fcs_vec <- list.files(
+    path_fcs,
+    pattern = "\\.fcs$",
+    recursive = TRUE,
+    full.names = TRUE,
+    ignore.case = TRUE
+  ) |>
+    sort()
+  if (length(fcs_vec) == 0L) {
+    stop("No FCS files found at: ", path_fcs)
+  }
+
+  if (!is.null(ind_sample)) {
+    if (anyNA(ind_sample) ||
+      any(ind_sample < 1L) ||
+      any(ind_sample > length(fcs_vec))) {
+      stop("ind_sample contains an index outside the available FCS files.")
+    }
+    fcs_vec <- fcs_vec[ind_sample]
+  } else if (!is.null(n_sample)) {
+    if (length(n_sample) != 1L ||
+      is.na(n_sample) ||
+      n_sample < 1L ||
+      n_sample > length(fcs_vec)) {
+      stop("n_sample must be between 1 and the number of available FCS files.")
+    }
+    fcs_vec <- fcs_vec[seq_len(n_sample)]
+  }
+
+  cs <- flowWorkspace::load_cytoset_from_fcs(fcs_vec)
 
   gs <- flowWorkspace::GatingSet(cs)
   forwardTransform <- function(x) {

--- a/scripts/slurm/dev-9-real-compare-acs-cytof.sh
+++ b/scripts/slurm/dev-9-real-compare-acs-cytof.sh
@@ -17,17 +17,18 @@ if [[ ! -f "$qmd_abs" ]]; then
   exit 1
 fi
 
-# Analysis 9 is intentionally sequential at the R level. Keep the Slurm
-# allocation small and cap common native-library thread pools at two cores.
-export OMP_NUM_THREADS="${OMP_NUM_THREADS:-2}"
-export OPENBLAS_NUM_THREADS="${OPENBLAS_NUM_THREADS:-2}"
-export MKL_NUM_THREADS="${MKL_NUM_THREADS:-2}"
-export VECLIB_MAXIMUM_THREADS="${VECLIB_MAXIMUM_THREADS:-2}"
-export NUMEXPR_NUM_THREADS="${NUMEXPR_NUM_THREADS:-2}"
+# Analysis 9 runs populations across two R workers. Keep native-library thread
+# pools single-threaded so the two-worker Slurm allocation is not oversubscribed.
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
+export OPENBLAS_NUM_THREADS="${OPENBLAS_NUM_THREADS:-1}"
+export MKL_NUM_THREADS="${MKL_NUM_THREADS:-1}"
+export VECLIB_MAXIMUM_THREADS="${VECLIB_MAXIMUM_THREADS:-1}"
+export NUMEXPR_NUM_THREADS="${NUMEXPR_NUM_THREADS:-1}"
 
 export RUN_PREPROCESSING="${RUN_PREPROCESSING:-true}"
 export RUN_METHODS="${RUN_METHODS:-true}"
 export RUN_PLOTS="${RUN_PLOTS:-false}"
+export ACS_N_WORKERS="${ACS_N_WORKERS:-${SLURM_NTASKS:-2}}"
 export PROJECT_ROOT="$project_root"
 
 cd "$project_root"
@@ -42,6 +43,7 @@ echo "PROJECT_ROOT: $project_root"
 echo "RUN_PREPROCESSING: $RUN_PREPROCESSING"
 echo "RUN_METHODS: $RUN_METHODS"
 echo "RUN_PLOTS: $RUN_PLOTS"
+echo "ACS_N_WORKERS: $ACS_N_WORKERS"
 echo "OMP_NUM_THREADS: $OMP_NUM_THREADS"
 
 echo " "


### PR DESCRIPTION
## Summary

- move the working ACS CyTOF preprocessing and StimGate flow into `scripts/r/acs_cytof-gate.R`
- run TCRgd first as a 20-sample tester using separate `tester/tcrgd` cache and scratch paths
- run the same helper afterwards for `tcrgd`, `cd4`, `cd8`, `nk`, `nk_pre`, and `b`
- keep population-level run flags and `biasUns` visible in the QMD while fixing shared StimGate settings, including `gateCombn = "min"`, in one place
- use up to two population workers and keep native thread pools single-threaded in the Slurm launcher
- make partial FCS selection deterministic and add analysis integration coverage for batching, path isolation, helper sourcing, and QMD wiring

The old Tailgate and F-beta chunks were deliberately disabled and referenced undefined scaffold objects. This PR removes those non-running copies from the TCRgd tester and leaves an explicit placeholder for adding them once their ACS method-grid and cache contract are complete.

Refs #348.

## Checks

- `git diff --check`
- `bash -n scripts/slurm/dev-9-real-compare-acs-cytof.sh`
- R tests were not run locally because `Rscript` is unavailable in this workspace; the analysis-integration workflow should provide executable verification.