### PR TITLE
Fix taut-string tie handling and degenerate native inputs

### DIFF
--- a/src/cpPmden.cpp
+++ b/src/cpPmden.cpp
@@ -63,6 +63,20 @@ std::vector<std::vector<double>> kuipdiffbounds = {kuip01,kuip02,kuip03,kuip04,k
 
 std::vector<double> kuipdiffbounds_x = {50.0, 100.0, 200.0, 500.0, 1000.0, 2000.0, 5000.0};
 
+namespace {
+stringInfo degenerateStringInfo(unsigned long n) {
+  stringInfo out = {
+    std::vector<double>(n > 1 ? n - 1 : 0, 0.0),
+    std::vector<int>(),
+    std::vector<double>(),
+    std::vector<double>(),
+    0,
+    0
+  };
+  return out;
+}
+}  // namespace
+
 stringInfo cpPmden(const std::vector<double>& xIn) {
   //sorting is currently turned off because cpPmden can only be called by tsGates, which is responsible for the sorting.
   //in the event cpPmden is to be used on a stand-alone basis, re-implement the sorting.
@@ -74,6 +88,9 @@ stringInfo cpPmden(const std::vector<double>& xIn) {
   int extrema_mean = 1; //parameter passed to tautstring C routine.
   int maxkuipnr = 19;
   unsigned long nsamp = x.size();
+  if (nsamp < 2) {
+    return degenerateStringInfo(nsamp);
+  }
   std::vector<double> currbounds(maxkuipnr,0.0);  //in this port, set maxkuipnr to 19. Do not allow user choice of mod.
 
   if (nsamp > 5000)  {
@@ -90,6 +107,9 @@ stringInfo cpPmden(const std::vector<double>& xIn) {
   dataemp[0] = 0.0;
   double acc_min = 1.0;
   double max_diff = (x[(nsamp-1)]-x[0]);
+  if (!std::isfinite(max_diff) || max_diff <= 0.0) {
+    return degenerateStringInfo(nsamp);
+  }
   double current_ratio = 1.0;
   for (auto i = 0; i < (int)(nsamp-1); i++) {
     current_ratio = (x[(i+1)]-x[i])/max_diff;
@@ -98,12 +118,15 @@ stringInfo cpPmden(const std::vector<double>& xIn) {
   }
   if (acc_min < 1e-14) {
     double accuracy = ((medianAbsoluteDeviation(xIn))/(1000.0));
+    if (!std::isfinite(accuracy) || accuracy <= 0.0) {
+      return degenerateStringInfo(nsamp);
+    }
     std::vector<double> newx;
     for (auto val : x)
       newx.push_back(val/accuracy);
     decltype(nsamp) j = 0, k, cur_ind;
     std::vector<decltype(nsamp)> ind;
-    double rhs, newaccx;
+    double rhs;
     while((j+1) < nsamp) {
       ind.clear();
       rhs = std::floor(newx[j]) + 1;
@@ -116,11 +139,12 @@ stringInfo cpPmden(const std::vector<double>& xIn) {
       else
 	k = *std::max_element(ind.begin(),ind.end());
       cur_ind = 1;
+      double group_floor = std::floor(newx[j]);
       for (auto i = j; i <= k; i++) {
-	newaccx = std::floor(newx[i]) + double(cur_ind)/double(k-j+2);
+	newx[i] = group_floor + double(cur_ind)/double(k-j+2);
 	cur_ind++;
       }
-      j++;
+      j = k + 1;
     }
     for (auto &i : newx)
       i = i * accuracy;

--- a/src/stimgate_cppmden.cpp
+++ b/src/stimgate_cppmden.cpp
@@ -4,10 +4,11 @@
  *
  * Responsibilities:
  *   1. Accept a numeric vector from R.
- *   2. Remove non-finite values at the R level (done before calling this).
+ *   2. Remove non-finite values defensively before entering native code.
  *   3. Sort the values (cpPmden requires sorted input).
- *   4. Call cpPmden().
- *   5. Return the `stringInfo.string` density vector and `nmax`.
+ *   4. Return a benign zero-density result for degenerate inputs.
+ *   5. Call cpPmden().
+ *   6. Return the `stringInfo.string` density vector and `nmax`.
  *
  * This file is part of stimgate and is licensed under GPL (>= 3).
  * The underlying cpPmden() implementation is derived from FAUST
@@ -16,25 +17,46 @@
  */
 
 #include <cpp11.hpp>
-#include <vector>
 #include <algorithm>
+#include <cmath>
+#include <vector>
 #include "faust.h"
+
+namespace {
+cpp11::list zero_density_result(unsigned long n) {
+  cpp11::writable::doubles dens(n > 1 ? n - 1 : 0);
+  std::fill(dens.begin(), dens.end(), 0.0);
+  using cpp11::literals::operator""_nm;
+  return cpp11::writable::list({"string"_nm = dens, "nmax"_nm = 0});
+}
+}  // namespace
 
 [[cpp11::register]]
 cpp11::list stimgate_cpPmden(std::vector<double> x) {
+  x.erase(
+    std::remove_if(
+      x.begin(),
+      x.end(),
+      [](double value) { return !std::isfinite(value); }
+    ),
+    x.end()
+  );
+
   // Sort: cpPmden() assumes sorted input.
   std::sort(x.begin(), x.end());
 
   unsigned long n = x.size();
 
-  // Return degenerate result for inputs too small for the algorithm.
   // cpPmden uses a Kuiper-bound table starting at n = 50; smaller inputs
-  // may not converge.
+  // may not converge. Constant input cannot define a density over positive-
+  // width intervals and would otherwise create zero denominators downstream.
   if (n < 50) {
-    cpp11::writable::doubles dens(n > 1 ? n - 1 : 0);
-    std::fill(dens.begin(), dens.end(), 0.0);
-    using cpp11::literals::operator""_nm;
-    return cpp11::writable::list({"string"_nm = dens, "nmax"_nm = 0});
+    return zero_density_result(n);
+  }
+
+  double range = x.back() - x.front();
+  if (!std::isfinite(range) || range <= 0.0) {
+    return zero_density_result(n);
   }
 
   stringInfo res = cpPmden(x);

--- a/tests/testthat/test-taut_string_density.R
+++ b/tests/testthat/test-taut_string_density.R
@@ -52,6 +52,36 @@ test_that(".tautStringPmden handles short input (n < 50) gracefully", {
   expect_length(res10$y, 9L)
 })
 
+test_that(".tautStringPmden handles exact ties without entering invalid native arithmetic", {
+  x <- sort(rep(seq(-2, 2, length.out = 60), each = 2L))
+  result <- .tautStringPmden(x)
+
+  expect_length(result$y, length(x) - 1L)
+  expect_true(all(is.finite(result$y)))
+  expect_true(all(result$y >= 0))
+  expect_true(any(result$y > 0))
+})
+
+test_that(".tautStringPmden returns a benign result for constant input", {
+  x <- rep(3, 100)
+  result <- .tautStringPmden(x)
+
+  expect_length(result$y, length(x) - 1L)
+  expect_true(all(is.finite(result$y)))
+  expect_true(all(result$y == 0))
+})
+
+test_that(".tautStringPmden returns a benign result when tie jitter has zero MAD", {
+  x <- sort(c(rep(0, 80), seq(1, 20, length.out = 20)))
+  expect_equal(stats::mad(x), 0)
+
+  result <- .tautStringPmden(x)
+
+  expect_length(result$y, length(x) - 1L)
+  expect_true(all(is.finite(result$y)))
+  expect_true(all(result$y == 0))
+})
+
 test_that(".tautStringPmden bimodal density has a clear dip between clusters", {
   # Two-cluster fixture with deterministic, well-separated groups (n=120)
   x <- c(seq(-1, 1, length.out = 60), seq(4, 6, length.out = 60))


### PR DESCRIPTION
## Summary

Hardens the vendored FAUST/ftnonpar taut-string density path against tied and degenerate CyTOF inputs.

This was prompted by the reproducible ACS CyTOF NK worker interruption immediately after smoothing, where an ordinary R error was not returned and the multisession worker process disappeared. This PR addresses a plausible native-code failure mode without changing the higher-level StimGate filtering logic.

## Changes

- Correct the `cpPmden()` near-tie adjustment to match the original `ftnonpar::pmden()` implementation:
  - actually assign the adjusted value back into `newx[i]`;
  - advance the group cursor with `j = k + 1` rather than `j++`;
  - use the common `floor(newx[j])` group base, matching the original R implementation.
- Return a benign zero-density result when the native estimator receives a zero/non-finite range or when tie jitter would require a zero/non-finite MAD-derived accuracy.
- Harden the cpp11 boundary by removing non-finite values before native execution and short-circuiting constant/too-short inputs.
- Add regression coverage for exact ties, constant inputs, and non-constant zero-MAD inputs.

## Rationale

The vendored FAUST port differs from the original `ftnonpar` tie-handling code in two consequential places: it calculated `newaccx` without storing it, and advanced only one observation after processing a tie group. With exact/near ties this can leave duplicate locations in place before `tautString()` performs divisions by knot/location differences.

The degenerate-input guards are deliberately conservative: when a meaningful positive-width taut-string density cannot be constructed safely, the antimode contribution becomes absent rather than allowing native arithmetic to terminate the R worker.

## Testing

Added focused package tests in `tests/testthat/test-taut_string_density.R` for:

- exact duplicated values with positive MAD;
- constant input;
- tied non-constant input with zero MAD;
- existing continuous/unimodal/bimodal fixtures remain covered by the pre-existing tests.

I have not run the package test suite in the connector environment; CI should compile the native code and run the package tests.