### PR TITLE
Compare cached Tailgate and F-beta ACS results

### DIFF
--- a/analysis/9-real-compare-acs-cytof.qmd
+++ b/analysis/9-real-compare-acs-cytof.qmd
@@ -7,6 +7,8 @@ format:
 params:
   run_preprocessing: true
   run_methods: true
+  run_comparators: true
+  overwrite_comparator_cache: false
   run_plots: false
   tester_n_sample: 20
   n_workers: 2
@@ -32,6 +34,8 @@ source(file.path(scripts_r_dir, "acs_cytof-helper.R"))
 source(file.path(scripts_r_dir, "acs_cytof-preprocess.R"))
 source(file.path(scripts_r_dir, "acs_cytof-gate.R"))
 source(file.path(scripts_r_dir, "sim-misc.R"))
+source(file.path(scripts_r_dir, "sim-compare-freq_bs.R"))
+source(file.path(scripts_r_dir, "acs_cytof-methods.R"))
 source(file.path(scripts_r_dir, "acs_cytof-manual.R"))
 
 run_preprocessing <- .as_flag(.get_qmd_param_env(
@@ -61,10 +65,28 @@ run_methods_vec_by_pop <- c(
   nk_pre = NULL %||% run_methods,
   b = NULL %||% run_methods
 )
+run_comparators <- .as_flag(.get_qmd_param_env(
+  "run_comparators",
+  "RUN_COMPARATORS",
+  TRUE
+))
+run_comparators_vec_by_pop <- c(
+  tcrgd = NULL %||% run_comparators,
+  cd4 = NULL %||% run_comparators,
+  cd8 = NULL %||% run_comparators,
+  nk = NULL %||% run_comparators,
+  nk_pre = NULL %||% run_comparators,
+  b = NULL %||% run_comparators
+)
+overwrite_comparator_cache <- .as_flag(.get_qmd_param_env(
+  "overwrite_comparator_cache",
+  "OVERWRITE_COMPARATOR_CACHE",
+  FALSE
+))
 run_plots <- .as_flag(.get_qmd_param_env(
   "run_plots",
   "RUN_PLOTS",
-  TRUE
+  FALSE
 ))
 run_plots_vec_by_pop <- c(
   tcrgd = NULL %||% run_plots,
@@ -79,7 +101,14 @@ tester_n_sample <- .get_qmd_param_env(
   "TESTER_N_SAMPLE",
   20L
 )
-n_workers <- max(1, .simGetCores())
+n_workers <- max(
+  1L,
+  as.integer(.get_qmd_param_env(
+    "n_workers",
+    "ACS_N_WORKERS",
+    2L
+  ))
+)
 bias_uns <- 0.15
 bias_uns_vec_by_pop <- c(
   tcrgd = NULL %||% bias_uns,
@@ -115,10 +144,11 @@ The TCRgd population is first run on a limited set of complete five-sample
 batches. If that tester completes successfully, the same preprocessing and
 StimGate flow is applied to every population configured in `pop_vec`.
 
-The reusable helper fixes the settings that are shared by these runs, including
-the six cytokine channels, `bwMtd = "hpi1"`, debug profiling and the required
-`gateCombn = "min"`. The population, stage controls, tester sample limit and
-`biasUns` remain visible here because they are the settings most likely to vary.
+The reusable helpers fix the six cytokine channels and the method settings.
+StimGate uses `bwMtd = "hpi1"` and `gateCombn = "min"`. F-beta uses its standard
+parameters (`beta = 0.8`, `theta = 2`, `width = 10` and automatic bin count).
+Tailgate uses the stimulated distribution, automatic bandwidth estimation and
+automatic tolerance tuning.
 
 ### Common paths
 
@@ -164,6 +194,17 @@ tcrgd_tester <- .acsCytofRunPopulation(
   nSample = tester_n_sample,
   biasUns = bias_uns_vec_by_pop[["tcrgd"]],
   outputGroup = "tester"
+)
+
+tcrgd_comparison_tester <- .acsCytofRunComparisonMethods(
+  pop = "tcrgd",
+  pathFcsBase = path_fcs_base,
+  pathGsBase = path_gs_base,
+  pathScratchBase = path_scratch_base,
+  runMethods = run_comparators,
+  nSample = tester_n_sample,
+  outputGroup = "tester",
+  overwrite = overwrite_comparator_cache
 )
 ```
 
@@ -235,16 +276,97 @@ if (length(failed_pop_vec) > 0L) {
 
 ## Tailgate and F-beta
 
-The reusable run above covers the currently working ACS preprocessing and
-StimGate path. Tailgate and F-beta will be added to the same population helper
-once their ACS method grid and result-cache contract have been completed.
+Tailgate and F-beta run one population at a time. Each method is saved
+immediately to its own `result.rds`; a later render reuses a complete cache when
+the sample count and fixed settings still match. Set
+`overwrite_comparator_cache` to `true` only when those method outputs need to
+be recomputed.
+
+```{r}
+#| label: run-comparison-methods-sequentially
+#| results: hide
+comparison_method_runs <- purrr::map(
+  pop_vec,
+  function(pop) {
+    .acsCytofRunComparisonMethodsSafe(
+      pop = pop,
+      pathFcsBase = path_fcs_base,
+      pathGsBase = path_gs_base,
+      pathScratchBase = path_scratch_base,
+      runMethods = run_comparators_vec_by_pop[[pop]],
+      overwrite = overwrite_comparator_cache
+    )
+  }
+)
+names(comparison_method_runs) <- pop_vec
+
+failed_comparator_pop_vec <- names(comparison_method_runs)[
+  !vapply(
+    comparison_method_runs,
+    function(x) isTRUE(x$success),
+    logical(1)
+  )
+]
+if (length(failed_comparator_pop_vec) > 0L) {
+  stop(
+    "ACS Tailgate/F-beta runs failed for: ",
+    paste(failed_comparator_pop_vec, collapse = ", "),
+    ". See the returned error entries in comparison_method_runs."
+  )
+}
+```
 
 ## Compare methods with the ACS reference counts
+
+The cached combination tables for all three methods are reduced to one
+frequency per cytokine with `UtilsCytoRSV::sum_over_markers()`. Combination
+labels are then normalised to the standard `+`/`-` form with
+`UtilsCompassSV::convert_cyt_combn_format()` before the automated and manual
+tables are joined. `nk_pre` is still run above, but is omitted here because the
+manual file has no matching population.
+
+```{r}
+#| label: format-manual-comparison
+path_manual_output <- file.path(
+  path_scratch_base,
+  "manual-comparison"
+)
+manual_comparison_tbl <- comp_against_manual_cyt(
+  fn = "Cytokines_10Jun2021_2.csv",
+  path_scratch_base = path_scratch_base,
+  path_fcs_base = path_fcs_base,
+  pop = pop_vec,
+  methods = c("stimgate", "tailgate", "fbeta"),
+  path_dir_save = path_manual_output,
+  save_plots = run_plots
+)
+manual_summary_tbl <- attr(manual_comparison_tbl, "summary")
+```
 
 ## Output tables and figures
 
 ### Save analysis tables
 
+The comparison table, its RDS copy and a method/population/cytokine summary are
+written under `path_manual_output` by the formatting step above.
+
+```{r}
+#| label: show-manual-summary
+manual_summary_tbl
+```
+
 ### Estimated versus reference response frequency
 
+```{r}
+#| label: plot-manual-comparison
+#| eval: run_plots
+.acsCytofManualPlotScatter(manual_comparison_tbl)
+```
+
 ### Relative error by method
+
+```{r}
+#| label: plot-manual-relative-error
+#| eval: run_plots
+.acsCytofManualPlotRelativeError(manual_comparison_tbl)
+```

--- a/analysis/tests/testthat/test-acs-cytof-gate.R
+++ b/analysis/tests/testthat/test-acs-cytof-gate.R
@@ -43,6 +43,14 @@ test_that("the TCRgd tester and full population use separate output paths", {
     tester$stimgate,
     file.path("scratch", "tester", "tcrgd", "stimgate")
   )
+  expect_equal(
+    tester$tailgate,
+    file.path("scratch", "tester", "tcrgd", "tailgate", "result.rds")
+  )
+  expect_equal(
+    tester$fbeta,
+    file.path("scratch", "tester", "tcrgd", "fbeta", "result.rds")
+  )
   expect_false(identical(full$stimgate, tester$stimgate))
 })
 
@@ -73,8 +81,24 @@ test_that("analysis 9 uses one runner for the tester and configured populations"
       content,
       gregexpr(".acsCytofRunPopulation(", content, fixed = TRUE)
     )),
-    2L
+    1L
   )
+  expect_true(grepl(".acsCytofRunPopulationSafe(", content, fixed = TRUE))
   expect_true(grepl('outputGroup = "tester"', content, fixed = TRUE))
   expect_true(grepl("furrr::future_map", content, fixed = TRUE))
+  expect_true(grepl(
+    ".acsCytofRunComparisonMethods(",
+    content,
+    fixed = TRUE
+  ))
+  expect_true(grepl(
+    "run-comparison-methods-sequentially",
+    content,
+    fixed = TRUE
+  ))
+  expect_true(grepl(
+    'methods = c("stimgate", "tailgate", "fbeta")',
+    content,
+    fixed = TRUE
+  ))
 })

--- a/analysis/tests/testthat/test-acs-cytof-methods.R
+++ b/analysis/tests/testthat/test-acs-cytof-methods.R
@@ -122,3 +122,38 @@ test_that("manual formatting uses the shared cytometry combination utilities", {
   ))
 })
 
+test_that("combination counts collapse to one positive row per cytokine", {
+  skip_if_not_installed("UtilsCytoRSV")
+  skip_if_not_installed("UtilsCompassSV")
+  env <- .load_acs_method_env()
+  channels <- names(env$.acsCytofChannelMap())
+  combinations <- env$.acsCytofCombinationLevels(channels)
+  stats_tbl <- tibble::tibble(
+    gateName = "loc_min",
+    ind = "2",
+    cytCombn = combinations,
+    countStim = 1L,
+    nCellStim = length(combinations),
+    countUns = 0L,
+    nCellUns = length(combinations)
+  )
+  sample_map <- tibble::tibble(
+    popCode = "cd4",
+    ind = "2",
+    SampleID = "000001_D0",
+    stim = "mtb"
+  )
+
+  out <- env$.acsCytofStatsSingleMarkers(
+    statsTbl = stats_tbl,
+    method = "stimgate",
+    popCode = "cd4",
+    popLabel = "CD4 T cells",
+    sampleMap = sample_map
+  )
+
+  expect_equal(nrow(out), length(channels))
+  expect_equal(out$countStim, rep(32L, length(channels)))
+  expect_equal(as.character(out$cyt), unname(env$.acsCytofChannelMap()))
+  expect_equal(out$cytCombn, paste0(out$cyt, "+"))
+})

--- a/analysis/tests/testthat/test-acs-cytof-methods.R
+++ b/analysis/tests/testthat/test-acs-cytof-methods.R
@@ -1,0 +1,124 @@
+root_dir <- normalizePath(file.path(testthat::test_path(), "../../.."), mustWork = TRUE)
+script_gate <- file.path(root_dir, "scripts", "r", "acs_cytof-gate.R")
+script_methods <- file.path(root_dir, "scripts", "r", "acs_cytof-methods.R")
+script_manual <- file.path(root_dir, "scripts", "r", "acs_cytof-manual.R")
+
+.load_acs_method_env <- function() {
+  env <- new.env(parent = getNamespace("stimgate"))
+  source(script_gate, local = env)
+  source(script_methods, local = env)
+  source(script_manual, local = env)
+  env
+}
+
+test_that("ACS comparator settings pin F-beta defaults and Tailgate auto tuning", {
+  env <- .load_acs_method_env()
+
+  fbeta <- env$.acsCytofComparatorSettings("fbeta")
+  expect_equal(fbeta$params$beta, 0.8)
+  expect_equal(fbeta$params$theta, 2)
+  expect_equal(fbeta$params$width, 10L)
+  expect_null(fbeta$params$numBins)
+
+  tailgate <- env$.acsCytofComparatorSettings("tailgate")
+  expect_identical(tailgate$params$tailgateX, "stim")
+  expect_null(tailgate$params$bandwidth)
+  expect_true(tailgate$params$autoTol)
+  expect_identical(tailgate$params$derivativeMethod, "firstDeriv")
+})
+
+test_that("thresholded cells are saved as a complete combination table", {
+  env <- .load_acs_method_env()
+  channels <- c("A", "B")
+  x_stim <- matrix(
+    c(0, 0, 2, 0, 0, 2, 2, 2),
+    ncol = 2L,
+    byrow = TRUE
+  )
+  x_uns <- matrix(c(0, 0, 2, 2), ncol = 2L, byrow = TRUE)
+
+  out <- env$.acsCytofCombinationCounts(
+    xStim = x_stim,
+    xUns = x_uns,
+    thresholds = c(A = 1, B = 1),
+    channels = channels
+  )
+
+  expect_equal(nrow(out), 4L)
+  expect_equal(sum(out$countStim), nrow(x_stim))
+  expect_equal(sum(out$countUns), nrow(x_uns))
+  expect_equal(out$countStim, rep(1L, 4L))
+  expect_equal(out$countUns, c(1L, 0L, 0L, 1L))
+})
+
+test_that("comparator cache validation includes settings and sample count", {
+  env <- .load_acs_method_env()
+  settings <- env$.acsCytofComparatorSettings("fbeta")
+  cache <- list(
+    settings = settings,
+    nSample = 10L,
+    stats = tibble::tibble(
+      method = "fbeta",
+      pop = "cd4",
+      ind = "2",
+      cytCombn = "A~+~",
+      countStim = 1L,
+      nCellStim = 2L,
+      countUns = 0L,
+      nCellUns = 2L
+    ),
+    thresholds = tibble::tibble(
+      method = "fbeta",
+      pop = "cd4",
+      ind = "2",
+      chnl = "A",
+      threshold = 1,
+      thresholdOrigin = "calculated",
+      thresholdFallbackUsed = FALSE
+    )
+  )
+
+  expect_true(env$.acsCytofCacheIsCurrent(cache, settings, nSample = 10L))
+  expect_false(env$.acsCytofCacheIsCurrent(cache, settings, nSample = 20L))
+
+  changed_settings <- settings
+  changed_settings$params$beta <- 1
+  expect_false(env$.acsCytofCacheIsCurrent(cache, changed_settings, nSample = 10L))
+})
+
+test_that("ACS comparison methods are deliberately sequential and cache each method", {
+  env <- .load_acs_method_env()
+  runner_body <- paste(
+    deparse(body(env$.acsCytofRunComparisonMethods)),
+    collapse = "\n"
+  )
+
+  expect_true(grepl("lapply(methodVec", runner_body, fixed = TRUE))
+  expect_false(grepl("future_map", runner_body, fixed = TRUE))
+  expect_true(grepl(".acsCytofWriteComparatorCache", runner_body, fixed = TRUE))
+  expect_true(grepl("Using cached", runner_body, fixed = TRUE))
+})
+
+test_that("manual formatting uses the shared cytometry combination utilities", {
+  env <- .load_acs_method_env()
+  formatter_body <- paste(
+    deparse(body(env$.acsCytofStatsSingleMarkers)),
+    collapse = "\n"
+  )
+  converter_body <- paste(
+    deparse(body(env$.acsCytofCombinationToStandard)),
+    collapse = "\n"
+  )
+
+  expect_true(grepl(
+    "UtilsCytoRSV::sum_over_markers",
+    formatter_body,
+    fixed = TRUE
+  ))
+  expect_true(grepl(
+    "UtilsCompassSV::convert_cyt_combn_format",
+    converter_body,
+    fixed = TRUE
+  ))
+})
+

--- a/scripts/r/acs_cytof-gate.R
+++ b/scripts/r/acs_cytof-gate.R
@@ -27,6 +27,8 @@
     scratch = pathScratch,
     gsCheck = file.path(pathScratch, "gatingset"),
     stimgate = file.path(pathScratch, "stimgate"),
+    tailgate = file.path(pathScratch, "tailgate", "result.rds"),
+    fbeta = file.path(pathScratch, "fbeta", "result.rds"),
     stimgateCheck = file.path(pathScratch, "stimgate_check.pdf")
   )
 }

--- a/scripts/r/acs_cytof-manual.R
+++ b/scripts/r/acs_cytof-manual.R
@@ -1,110 +1,738 @@
-.comp_against_manual_cyt_format_manual <- function(fn, pop, cyt) {
-  # load
-  manual_tbl <- suppressMessages(suppressWarnings(readr::read_csv(
-    projr::projr_path_get(
-      "raw-data-small",
-      "comparison_data",
-      "acscytof",
-      fn
-    )
+.acsCytofManualPopulationMap <- function() {
+  c(
+    tcrgd = "TCRgd T cells",
+    cd4 = "CD4 T cells",
+    cd8 = "CD8 T cells",
+    nk = "NK cells",
+    nk_pre = NA_character_,
+    b = "B cells"
+  )
+}
+
+.acsCytofManualNormaliseId <- function(x) {
+  x |>
+    basename() |>
+    tools::file_path_sans_ext() |>
+    stringr::str_to_lower() |>
+    stringr::str_replace_all("[^[:alnum:]]", "")
+}
+
+.acsCytofManualRead <- function(fn) {
+  pathManual <- projr::projr_path_get(
+    "raw-data-small",
+    "comparison_data",
+    "acscytof",
+    fn
+  )
+  if (!file.exists(pathManual)) {
+    stop("Manual ACS cytokine file not found at: ", pathManual)
+  }
+
+  manualRaw <- suppressMessages(suppressWarnings(readr::read_csv(
+    pathManual,
+    name_repair = "unique",
+    show_col_types = FALSE
   )))
+  idCol <- names(manualRaw)[[1]]
+  sourceId <- as.character(manualRaw[[idCol]])
+  sourceParts <- stringr::str_split(sourceId, "_")
+  if (any(lengths(sourceParts) < 5L)) {
+    stop("Could not parse SampleID and stimulus from the manual ACS file.")
+  }
 
-  # remove empty columns
-  manual_tbl <- manual_tbl |>
-    dplyr::select(-(...58:...62))
-
-  # get info
-  manual_tbl <- manual_tbl |>
-    dplyr::bind_cols(
-      stringr::str_split(manual_tbl$`...1`, "_") |>
-        purrr::map_df(function(x) {
-          tibble::tibble(
-            SampleID = paste0(x[1], "_", x[2]),
-            stim = x[5]
-          )
-        })
+  sampleLookup <- tibble::tibble(
+    sourceId = sourceId,
+    SampleID = purrr::map_chr(
+      sourceParts,
+      function(x) paste0(x[[1]], "_", x[[2]])
+    ),
+    stim = purrr::map_chr(sourceParts, function(x) x[[5]]),
+    pid = stringr::str_extract(
+      stringr::str_to_lower(sourceId),
+      "pid[12]"
+    )
+  ) |>
+    dplyr::mutate(
+      stim = dplyr::if_else(.data$stim == "mtbaux", "mtb", .data$stim),
+      sourceKey = .acsCytofManualNormaliseId(.data$sourceId)
     ) |>
-    dplyr::select(SampleID, stim, everything()) |>
-    dplyr::select(-`...1`)
+    dplyr::distinct()
 
-  # remove "_FreqofParent" from column name
-  colnames(manual_tbl) <- stringr::str_remove(
-    colnames(manual_tbl),
-    " FreqofParent"
+  emptyCol <- vapply(
+    manualRaw,
+    function(x) {
+      xCharacter <- trimws(as.character(x))
+      all(is.na(x) | is.na(xCharacter) | !nzchar(xCharacter))
+    },
+    logical(1)
+  )
+  emptyCol[[idCol]] <- FALSE
+
+  list(
+    data = manualRaw[, !emptyCol, drop = FALSE],
+    idCol = idCol,
+    sampleLookup = sampleLookup
+  )
+}
+
+.comp_against_manual_cyt_format_manual <- function(
+    fn,
+    pop = NULL,
+    cyt = NULL) {
+  manualObject <- .acsCytofManualRead(fn)
+  idCol <- manualObject$idCol
+
+  manualTbl <- manualObject$data |>
+    dplyr::mutate(.sourceId = as.character(.data[[idCol]])) |>
+    dplyr::left_join(
+      manualObject$sampleLookup |>
+        dplyr::select(.sourceId = sourceId, SampleID, stim),
+      by = ".sourceId"
+    ) |>
+    dplyr::select(-dplyr::all_of(idCol))
+  names(manualTbl) <- stringr::str_remove(
+    names(manualTbl),
+    " FreqofParent$"
   )
 
-  # pivot longer
-  manual_tbl <- manual_tbl |>
+  manualTbl <- manualTbl |>
     tidyr::pivot_longer(
-      -c(SampleID, stim),
-      names_to = "pop",
-      values_to = "freq"
-    )
-
-  # split pop into pop and cyt
-  manual_tbl <- manual_tbl |>
+      cols = -c(.sourceId, SampleID, stim),
+      names_to = "popCyt",
+      values_to = "freq_stim_man"
+    ) |>
     tidyr::separate(
-      col = pop,
+      col = "popCyt",
+      into = c("pop", "cyt"),
       sep = "/",
-      into = c("pop", "cyt")
+      extra = "merge",
+      fill = "right"
+    ) |>
+    dplyr::filter(!is.na(.data$cyt), .data$cyt != "Perf") |>
+    dplyr::mutate(
+      pop = dplyr::if_else(
+        .data$pop == "TCRgd+",
+        "TCRgd T cells",
+        .data$pop
+      ),
+      freq_stim_man = as.numeric(.data$freq_stim_man)
     )
 
-  # remove Perf
-  manual_tbl <- manual_tbl |>
-    dplyr::filter(!cyt == "Perf")
+  manualUns <- manualTbl |>
+    dplyr::filter(.data$stim == "uns") |>
+    dplyr::count(SampleID, pop, cyt, name = "nUns")
+  if (any(manualUns$nUns != 1L)) {
+    stop("The manual file has repeated unstimulated population/cytokine rows.")
+  }
 
-  # rename mtbaux as mtb
-  manual_tbl <- manual_tbl |>
-    dplyr::mutate(stim = ifelse(stim == "mtbaux", "mtb", stim))
+  manualUns <- manualTbl |>
+    dplyr::filter(.data$stim == "uns") |>
+    dplyr::select(
+      SampleID,
+      pop,
+      cyt,
+      freq_uns_man = freq_stim_man
+    )
+  missingUns <- manualTbl |>
+    dplyr::distinct(SampleID, pop, cyt) |>
+    dplyr::anti_join(manualUns, by = c("SampleID", "pop", "cyt"))
+  if (nrow(missingUns) > 0L) {
+    stop("The manual file is missing an unstimulated population/cytokine row.")
+  }
 
-  # rename freq as freq_stim
-  manual_tbl <- manual_tbl |>
-    dplyr::rename(freq_stim = freq)
-
-  # subtract unstim
-  manual_tbl <- manual_tbl |>
-    dplyr::group_by(SampleID, pop, cyt) |>
-    dplyr::mutate(freq_uns = freq_stim[stim == "uns"]) |>
-    dplyr::ungroup() |>
-    dplyr::mutate(freq_bs = freq_stim - freq_uns) |>
+  manualTbl <- manualTbl |>
+    dplyr::left_join(manualUns, by = c("SampleID", "pop", "cyt")) |>
+    dplyr::mutate(
+      freq_bs_man = pmax(.data$freq_stim_man - .data$freq_uns_man, 0)
+    ) |>
     dplyr::select(
       SampleID,
       stim,
       pop,
       cyt,
-      freq_stim,
-      freq_uns,
-      freq_bs
-    ) |>
-    dplyr::rename(
-      freq_bs_man = freq_bs,
-      freq_stim_man = freq_stim,
-      freq_uns_man = freq_uns
+      freq_stim_man,
+      freq_uns_man,
+      freq_bs_man
     )
-
-  # set freq_bs <0 to 0
-  manual_tbl <- manual_tbl |>
-    dplyr::mutate(freq_bs_man = pmax(freq_bs_man, 0))
-
-  # rename TCRgd+ to TCRgd T cells
-  manual_tbl <- manual_tbl |>
-    dplyr::mutate(
-      pop = ifelse(
-        pop == "TCRgd+",
-        "TCRgd T cells",
-        pop
-      )
-    )
-
-  # filter pop, if not NULL
   if (!is.null(pop)) {
-    manual_tbl <- manual_tbl |> dplyr::filter(pop %in% .env$pop)
+    manualTbl <- dplyr::filter(manualTbl, .data$pop %in% .env$pop)
   }
-
-  # filter cyt, if not NULL
   if (!is.null(cyt)) {
-    manual_tbl <- manual_tbl |> dplyr::filter(cyt %in% .env$cyt)
+    manualTbl <- dplyr::filter(manualTbl, .data$cyt %in% .env$cyt)
+  }
+  manualTbl
+}
+
+.acsCytofManualResolvePopCodes <- function(pop, popMap) {
+  if (is.null(pop)) {
+    return(names(popMap))
   }
 
-  manual_tbl
+  unique(purrr::map_chr(pop, function(x) {
+    if (x %in% names(popMap)) {
+      return(x)
+    }
+    matchIndex <- which(!is.na(popMap) & popMap == x)
+    if (length(matchIndex) == 1L) {
+      return(names(popMap)[[matchIndex]])
+    }
+    stop("Unknown or unsupported ACS population: ", x)
+  }))
+}
+
+.acsCytofManualStimPattern <- function(stim) {
+  switch(
+    stim,
+    mtb = "(^|[^[:alnum:]])mtb(aux)?([^[:alnum:]]|$)",
+    paste0("(^|[^[:alnum:]])", stim, "([^[:alnum:]]|$)")
+  )
+}
+
+.acsCytofManualMatchOneFcs <- function(fcs, sampleLookup) {
+  fcsKey <- .acsCytofManualNormaliseId(fcs)
+  exactIndex <- which(
+    nzchar(sampleLookup$sourceKey) &
+      (
+        stringr::str_detect(fcsKey, stringr::fixed(sampleLookup$sourceKey)) |
+          stringr::str_detect(sampleLookup$sourceKey, stringr::fixed(fcsKey))
+      )
+  )
+  if (length(exactIndex) == 1L) {
+    return(exactIndex)
+  }
+
+  fcsLower <- stringr::str_to_lower(basename(fcs))
+  sampleKey <- .acsCytofManualNormaliseId(sampleLookup$SampleID)
+  sampleIndex <- which(stringr::str_detect(
+    fcsKey,
+    stringr::fixed(sampleKey)
+  ))
+  if (length(sampleIndex) == 0L) {
+    return(NA_integer_)
+  }
+
+  stimMatch <- vapply(
+    sampleLookup$stim[sampleIndex],
+    function(stim) {
+      stringr::str_detect(
+        fcsLower,
+        stringr::regex(
+          .acsCytofManualStimPattern(stim),
+          ignore_case = TRUE
+        )
+      )
+    },
+    logical(1)
+  )
+  sampleIndex <- sampleIndex[stimMatch]
+
+  fcsPid <- stringr::str_extract(fcsLower, "pid[12]")
+  if (length(sampleIndex) > 1L && !is.na(fcsPid)) {
+    pidMatch <- sampleLookup$pid[sampleIndex] == fcsPid
+    pidMatch[is.na(pidMatch)] <- FALSE
+    sampleIndex <- sampleIndex[pidMatch]
+  }
+  if (length(sampleIndex) == 1L) sampleIndex else NA_integer_
+}
+
+.acsCytofManualSampleMapFromFcs <- function(
+    pathFcsBase,
+    popCode,
+    sampleLookup) {
+  fcsFiles <- .acsCytofFcsFiles(file.path(pathFcsBase, popCode))
+  lookupIndex <- vapply(
+    fcsFiles,
+    .acsCytofManualMatchOneFcs,
+    integer(1),
+    sampleLookup = sampleLookup
+  )
+  matched <- sampleLookup[lookupIndex, , drop = FALSE]
+
+  tibble::tibble(
+    popCode = popCode,
+    ind = as.character(seq_along(fcsFiles)),
+    SampleID = matched$SampleID,
+    stim = matched$stim
+  ) |>
+    dplyr::filter(!is.na(.data$SampleID), !is.na(.data$stim))
+}
+
+.acsCytofManualValidateSampleMap <- function(sampleMap, popCodes) {
+  requiredColumns <- c("popCode", "ind", "SampleID", "stim")
+  missingColumns <- setdiff(requiredColumns, names(sampleMap))
+  if (length(missingColumns) > 0L) {
+    stop(
+      "sampleMap is missing required column(s): ",
+      paste(missingColumns, collapse = ", ")
+    )
+  }
+
+  sampleMap <- sampleMap |>
+    dplyr::transmute(
+      popCode = as.character(.data$popCode),
+      ind = as.character(.data$ind),
+      SampleID = as.character(.data$SampleID),
+      stim = dplyr::if_else(
+        .data$stim == "mtbaux",
+        "mtb",
+        as.character(.data$stim)
+      )
+    ) |>
+    dplyr::filter(.data$popCode %in% .env$popCodes)
+
+  duplicateMap <- sampleMap |>
+    dplyr::count(popCode, ind, name = "n") |>
+    dplyr::filter(.data$n != 1L)
+  if (nrow(duplicateMap) > 0L) {
+    stop("sampleMap has duplicate popCode/ind keys.")
+  }
+  sampleMap
+}
+
+.acsCytofManualMethodPath <- function(
+    pathScratchBase,
+    popCode,
+    method,
+    outputGroup = NULL) {
+  pathParts <- c(
+    pathScratchBase,
+    if (!is.null(outputGroup)) outputGroup,
+    popCode
+  )
+  pathPopulation <- do.call(file.path, as.list(pathParts))
+
+  switch(
+    method,
+    stimgate = file.path(pathPopulation, "stimgate"),
+    tailgate = file.path(pathPopulation, "tailgate", "result.rds"),
+    fbeta = file.path(pathPopulation, "fbeta", "result.rds"),
+    stop("Unknown ACS method: ", method)
+  )
+}
+
+.acsCytofManualReadStats <- function(path, method, gateName) {
+  if (identical(method, "stimgate")) {
+    if (!dir.exists(path)) {
+      stop("StimGate output not found at: ", path)
+    }
+    statsTbl <- stimgate::getStimStats(path) |>
+      dplyr::filter(.data$gateName == .env$gateName) |>
+      dplyr::mutate(method = "stimgate")
+    if (nrow(statsTbl) == 0L) {
+      stop("No '", gateName, "' rows were found at: ", path)
+    }
+    return(statsTbl)
+  }
+
+  .acsCytofReadComparatorCache(path = path, method = method)$stats
+}
+
+.acsCytofCombinationToStandard <- function(cytCombn, channelMap) {
+  combinationStd <- cytCombn |>
+    stringr::str_replace_all("~\\+~", "+") |>
+    stringr::str_replace_all("~-~", "-")
+  combinationCompass <- UtilsCompassSV::convert_cyt_combn_format(
+    cyt_combn = combinationStd,
+    to = "compass",
+    silent = TRUE,
+    lab = channelMap
+  )
+  UtilsCompassSV::convert_cyt_combn_format(
+    cyt_combn = combinationCompass,
+    to = "std",
+    silent = TRUE
+  )
+}
+
+.acsCytofStatsSingleMarkers <- function(
+    statsTbl,
+    method,
+    popCode,
+    popLabel,
+    sampleMap,
+    cyt = NULL) {
+  requiredColumns <- c(
+    "ind", "cytCombn", "countStim", "nCellStim",
+    "countUns", "nCellUns"
+  )
+  missingColumns <- setdiff(requiredColumns, names(statsTbl))
+  if (length(missingColumns) > 0L) {
+    stop(
+      method,
+      " stats for '",
+      popCode,
+      "' are missing column(s): ",
+      paste(missingColumns, collapse = ", ")
+    )
+  }
+
+  channelMap <- .acsCytofChannelMap()
+  channels <- names(channelMap)
+  channelsToKeep <- channels
+  if (!is.null(cyt)) {
+    channelsToKeep <- channels[channelMap %in% cyt]
+  }
+
+  statsTbl <- statsTbl |>
+    dplyr::mutate(
+      ind = as.character(.data$ind),
+      method = .env$method,
+      popCode = .env$popCode
+    )
+  groupColumns <- intersect(
+    c(
+      "gateName", "method", "popCode", "pop", "batch",
+      "ind", "indUns", "nCellStim", "nCellUns"
+    ),
+    names(statsTbl)
+  )
+
+  singleTbl <- purrr::map_dfr(channelsToKeep, function(channel) {
+    UtilsCytoRSV::sum_over_markers(
+      .data = statsTbl,
+      grp = groupColumns,
+      cmbn = "cytCombn",
+      levels = c("~+~", "~-~"),
+      markers_to_sum = setdiff(channels, channel),
+      resp = c("countStim", "countUns")
+    ) |>
+      dplyr::filter(.data$cytCombn == paste0(channel, "~+~"))
+  }) |>
+    dplyr::mutate(
+      cytCombn = .acsCytofCombinationToStandard(
+        .data$cytCombn,
+        channelMap = channelMap
+      ),
+      cyt = stringr::str_remove(.data$cytCombn, "[+-]$")
+    )
+
+  mapPopulation <- sampleMap |>
+    dplyr::filter(.data$popCode == .env$popCode) |>
+    dplyr::select(ind, SampleID, stim)
+
+  singleTbl |>
+    dplyr::inner_join(mapPopulation, by = "ind") |>
+    dplyr::mutate(
+      pop = .env$popLabel,
+      freq_stim_auto = .data$countStim / .data$nCellStim * 100,
+      freq_uns_auto = .data$countUns / .data$nCellUns * 100,
+      freq_bs_auto = pmax(.data$freq_stim_auto - .data$freq_uns_auto, 0)
+    ) |>
+    dplyr::select(
+      method,
+      SampleID,
+      stim,
+      popCode,
+      pop,
+      cyt,
+      cytCombn,
+      dplyr::any_of(c("gateName", "batch", "ind", "indUns")),
+      countStim,
+      nCellStim,
+      countUns,
+      nCellUns,
+      freq_stim_auto,
+      freq_uns_auto,
+      freq_bs_auto
+    )
+}
+
+.acsCytofManualAutoTable <- function(
+    pathScratchBase,
+    pathFcsBase,
+    fn,
+    pop = NULL,
+    cyt = NULL,
+    methods = c("stimgate", "tailgate", "fbeta"),
+    outputGroup = NULL,
+    gateName = "loc_min",
+    sampleMap = NULL) {
+  methods <- match.arg(
+    methods,
+    choices = c("stimgate", "tailgate", "fbeta"),
+    several.ok = TRUE
+  )
+  popMap <- .acsCytofManualPopulationMap()
+  popCodes <- .acsCytofManualResolvePopCodes(pop, popMap)
+  noManual <- popCodes[is.na(popMap[popCodes])]
+  if (length(noManual) > 0L) {
+    warning(
+      "No matching manual population exists for: ",
+      paste(noManual, collapse = ", "),
+      ". These population(s) will not be included."
+    )
+    popCodes <- setdiff(popCodes, noManual)
+  }
+
+  if (is.null(pop)) {
+    hasStimGate <- vapply(popCodes, function(popCode) {
+      dir.exists(.acsCytofManualMethodPath(
+        pathScratchBase,
+        popCode,
+        method = "stimgate",
+        outputGroup = outputGroup
+      ))
+    }, logical(1))
+    popCodes <- popCodes[hasStimGate]
+  }
+  if (length(popCodes) == 0L) {
+    stop("No requested ACS population has an automated and manual result.")
+  }
+
+  if (is.null(sampleMap)) {
+    sampleLookup <- .acsCytofManualRead(fn)$sampleLookup
+    sampleMap <- purrr::map_dfr(popCodes, function(popCode) {
+      .acsCytofManualSampleMapFromFcs(
+        pathFcsBase = pathFcsBase,
+        popCode = popCode,
+        sampleLookup = sampleLookup
+      )
+    })
+  }
+  sampleMap <- .acsCytofManualValidateSampleMap(sampleMap, popCodes)
+
+  purrr::map_dfr(popCodes, function(popCode) {
+    purrr::map_dfr(methods, function(method) {
+      statsTbl <- .acsCytofManualReadStats(
+        path = .acsCytofManualMethodPath(
+          pathScratchBase,
+          popCode,
+          method,
+          outputGroup
+        ),
+        method = method,
+        gateName = gateName
+      )
+      .acsCytofStatsSingleMarkers(
+        statsTbl = statsTbl,
+        method = method,
+        popCode = popCode,
+        popLabel = unname(popMap[[popCode]]),
+        sampleMap = sampleMap,
+        cyt = cyt
+      )
+    })
+  })
+}
+
+.acsCytofManualComparisonTable <- function(
+    fn,
+    pathScratchBase,
+    pathFcsBase,
+    pop = NULL,
+    cyt = NULL,
+    methods = c("stimgate", "tailgate", "fbeta"),
+    outputGroup = NULL,
+    gateName = "loc_min",
+    sampleMap = NULL) {
+  autoTbl <- .acsCytofManualAutoTable(
+    pathScratchBase = pathScratchBase,
+    pathFcsBase = pathFcsBase,
+    fn = fn,
+    pop = pop,
+    cyt = cyt,
+    methods = methods,
+    outputGroup = outputGroup,
+    gateName = gateName,
+    sampleMap = sampleMap
+  )
+  manualTbl <- .comp_against_manual_cyt_format_manual(
+    fn = fn,
+    pop = unique(autoTbl$pop),
+    cyt = cyt
+  ) |>
+    dplyr::filter(.data$stim != "uns")
+
+  joinBy <- c("SampleID", "stim", "pop", "cyt")
+  methodLevels <- c("stimgate", "tailgate", "fbeta")
+  popLevels <- stats::na.omit(unname(.acsCytofManualPopulationMap()))
+  cytLevels <- unname(.acsCytofChannelMap())
+
+  autoTbl |>
+    dplyr::inner_join(manualTbl, by = joinBy) |>
+    dplyr::mutate(
+      method = factor(.data$method, levels = methodLevels),
+      pop = factor(.data$pop, levels = popLevels),
+      cyt = factor(.data$cyt, levels = cytLevels),
+      diff = .data$freq_bs_auto - .data$freq_bs_man,
+      abs_diff = abs(.data$diff),
+      rel_error = dplyr::if_else(
+        .data$freq_bs_man > 0,
+        .data$diff / .data$freq_bs_man,
+        NA_real_
+      ),
+      abs_rel_error = abs(.data$rel_error)
+    ) |>
+    dplyr::arrange(
+      .data$method,
+      .data$pop,
+      .data$cyt,
+      dplyr::desc(.data$abs_diff)
+    )
+}
+
+.acsCytofManualSummaryTable <- function(comparisonTbl) {
+  comparisonTbl |>
+    dplyr::group_by(method, pop, cyt, stim) |>
+    dplyr::summarise(
+      n = sum(stats::complete.cases(
+        .data$freq_bs_auto,
+        .data$freq_bs_man
+      )),
+      pcc = if (dplyr::n() > 1L) {
+        suppressWarnings(stats::cor(
+          .data$freq_bs_auto,
+          .data$freq_bs_man,
+          use = "complete.obs"
+        ))
+      } else {
+        NA_real_
+      },
+      mae = mean(.data$abs_diff, na.rm = TRUE),
+      median_abs_rel_error = stats::median(
+        .data$abs_rel_error,
+        na.rm = TRUE
+      ),
+      .groups = "drop"
+    )
+}
+
+.acsCytofManualPlotScatter <- function(comparisonTbl) {
+  ggplot2::ggplot(
+    comparisonTbl,
+    ggplot2::aes(
+      x = .data$freq_bs_man,
+      y = .data$freq_bs_auto,
+      colour = .data$method,
+      shape = .data$stim
+    )
+  ) +
+    ggplot2::geom_abline(
+      intercept = 0,
+      slope = 1,
+      colour = "grey45",
+      linetype = "dashed"
+    ) +
+    ggplot2::geom_point(alpha = 0.7) +
+    ggplot2::facet_grid(
+      rows = ggplot2::vars(pop),
+      cols = ggplot2::vars(cyt),
+      scales = "free"
+    ) +
+    ggplot2::labs(
+      x = "Background-subtracted frequency (manual gating, %)",
+      y = "Background-subtracted frequency (automated gating, %)",
+      colour = "Method",
+      shape = "Stimulus"
+    ) +
+    cowplot::theme_cowplot() +
+    cowplot::background_grid(major = "xy") +
+    ggplot2::theme(legend.position = "bottom")
+}
+
+.acsCytofManualPlotRelativeError <- function(comparisonTbl) {
+  ggplot2::ggplot(
+    comparisonTbl,
+    ggplot2::aes(
+      x = .data$method,
+      y = .data$abs_rel_error,
+      fill = .data$method
+    )
+  ) +
+    ggplot2::geom_boxplot(outlier.alpha = 0.25) +
+    ggplot2::facet_grid(
+      rows = ggplot2::vars(pop),
+      cols = ggplot2::vars(cyt),
+      scales = "free_y"
+    ) +
+    ggplot2::labs(x = NULL, y = "Absolute relative error") +
+    cowplot::theme_cowplot() +
+    cowplot::background_grid(major = "y") +
+    ggplot2::theme(
+      legend.position = "none",
+      axis.text.x = ggplot2::element_text(angle = 45, hjust = 1)
+    )
+}
+
+.acsCytofManualSave <- function(
+    comparisonTbl,
+    pathDirSave,
+    savePlots = TRUE) {
+  dir.create(pathDirSave, recursive = TRUE, showWarnings = FALSE)
+  summaryTbl <- .acsCytofManualSummaryTable(comparisonTbl)
+
+  utils::write.csv(
+    comparisonTbl,
+    file.path(pathDirSave, "manual-comparison.csv"),
+    row.names = FALSE
+  )
+  saveRDS(comparisonTbl, file.path(pathDirSave, "manual-comparison.rds"))
+  utils::write.csv(
+    summaryTbl,
+    file.path(pathDirSave, "manual-comparison-summary.csv"),
+    row.names = FALSE
+  )
+
+  if (!isTRUE(savePlots)) {
+    return(invisible(list(summary = summaryTbl)))
+  }
+
+  scatter <- .acsCytofManualPlotScatter(comparisonTbl)
+  relativeError <- .acsCytofManualPlotRelativeError(comparisonTbl)
+  nPop <- max(1L, dplyr::n_distinct(comparisonTbl$pop))
+  ggplot2::ggsave(
+    file.path(pathDirSave, "manual-comparison-scatter.png"),
+    plot = scatter,
+    width = 30,
+    height = max(16, 5 * nPop),
+    units = "cm"
+  )
+  ggplot2::ggsave(
+    file.path(pathDirSave, "manual-comparison-relative-error.png"),
+    plot = relativeError,
+    width = 30,
+    height = max(16, 5 * nPop),
+    units = "cm"
+  )
+
+  invisible(list(
+    scatter = scatter,
+    relativeError = relativeError,
+    summary = summaryTbl
+  ))
+}
+
+comp_against_manual_cyt <- function(
+    fn,
+    path_scratch_base,
+    path_fcs_base,
+    pop = NULL,
+    cyt = NULL,
+    methods = c("stimgate", "tailgate", "fbeta"),
+    output_group = NULL,
+    gate_name = "loc_min",
+    sample_map = NULL,
+    path_dir_save = NULL,
+    save_plots = TRUE) {
+  comparisonTbl <- .acsCytofManualComparisonTable(
+    fn = fn,
+    pathScratchBase = path_scratch_base,
+    pathFcsBase = path_fcs_base,
+    pop = pop,
+    cyt = cyt,
+    methods = methods,
+    outputGroup = output_group,
+    gateName = gate_name,
+    sampleMap = sample_map
+  )
+  attr(comparisonTbl, "summary") <- .acsCytofManualSummaryTable(comparisonTbl)
+
+  if (!is.null(path_dir_save)) {
+    .acsCytofManualSave(
+      comparisonTbl = comparisonTbl,
+      pathDirSave = path_dir_save,
+      savePlots = save_plots
+    )
+  }
+  invisible(comparisonTbl)
 }

--- a/scripts/r/acs_cytof-manual.R
+++ b/scripts/r/acs_cytof-manual.R
@@ -370,6 +370,13 @@
   channels <- names(channelMap)
   channelsToKeep <- channels
   if (!is.null(cyt)) {
+    unknownCytokines <- setdiff(cyt, unname(channelMap))
+    if (length(unknownCytokines) > 0L) {
+      stop(
+        "Unknown ACS cytokine label(s): ",
+        paste(unknownCytokines, collapse = ", ")
+      )
+    }
     channelsToKeep <- channels[channelMap %in% cyt]
   }
 
@@ -409,6 +416,17 @@
   mapPopulation <- sampleMap |>
     dplyr::filter(.data$popCode == .env$popCode) |>
     dplyr::select(ind, SampleID, stim)
+  unmatchedIndex <- setdiff(unique(singleTbl$ind), mapPopulation$ind)
+  if (length(unmatchedIndex) > 0L) {
+    warning(
+      length(unmatchedIndex),
+      " ",
+      method,
+      " sample(s) in population '",
+      popCode,
+      "' could not be matched to the manual file and will be omitted."
+    )
+  }
 
   singleTbl |>
     dplyr::inner_join(mapPopulation, by = "ind") |>
@@ -544,6 +562,20 @@
     dplyr::filter(.data$stim != "uns")
 
   joinBy <- c("SampleID", "stim", "pop", "cyt")
+  unmatchedAuto <- autoTbl |>
+    dplyr::anti_join(manualTbl, by = joinBy)
+  unmatchedManual <- manualTbl |>
+    dplyr::anti_join(autoTbl, by = joinBy)
+  if (nrow(unmatchedAuto) > 0L || nrow(unmatchedManual) > 0L) {
+    warning(
+      "The manual join omitted ",
+      nrow(unmatchedAuto),
+      " automated row(s) and ",
+      nrow(unmatchedManual),
+      " manual row(s) with no matching key."
+    )
+  }
+
   methodLevels <- c("stimgate", "tailgate", "fbeta")
   popLevels <- stats::na.omit(unname(.acsCytofManualPopulationMap()))
   cytLevels <- unname(.acsCytofChannelMap())

--- a/scripts/r/acs_cytof-methods.R
+++ b/scripts/r/acs_cytof-methods.R
@@ -1,0 +1,522 @@
+.acsCytofChannelMap <- function() {
+  c(
+    Ho165Di = "IFNg",
+    Gd158Di = "IL2",
+    Nd146Di = "TNF",
+    Dy164Di = "IL17",
+    Gd156Di = "IL6",
+    Nd150Di = "IL22"
+  )
+}
+
+.acsCytofComparatorSettings <- function(method = c("tailgate", "fbeta")) {
+  method <- match.arg(method)
+
+  params <- switch(
+    method,
+    tailgate = list(
+      tailgateX = "stim",
+      adjust = 1,
+      bandwidth = NULL,
+      numPeaks = 1L,
+      refPeak = 1L,
+      derivativeMethod = "firstDeriv",
+      tol = 1e-2,
+      side = "right",
+      strict = FALSE,
+      autoTol = TRUE
+    ),
+    fbeta = list(
+      beta = 0.8,
+      theta = 2,
+      width = 10L,
+      numBins = NULL,
+      patchPy2Compat = TRUE
+    )
+  )
+
+  list(
+    cacheVersion = 1L,
+    method = method,
+    channelMap = .acsCytofChannelMap(),
+    params = params
+  )
+}
+
+.acsCytofCombinationLevels <- function(channels) {
+  if (length(channels) == 0L || anyNA(channels) || any(!nzchar(channels))) {
+    stop("channels must contain at least one non-empty channel name.")
+  }
+
+  levelGrid <- expand.grid(
+    rep(list(c(FALSE, TRUE)), length(channels)),
+    KEEP.OUT.ATTRS = FALSE,
+    stringsAsFactors = FALSE
+  )
+
+  apply(levelGrid, 1L, function(isPositive) {
+    paste0(
+      paste0(channels, ifelse(isPositive, "~+~", "~-~")),
+      collapse = ""
+    )
+  })
+}
+
+.acsCytofCombinationLabels <- function(isPositive, channels) {
+  isPositive <- as.matrix(isPositive)
+  if (ncol(isPositive) != length(channels)) {
+    stop("The positivity matrix must have one column per channel.")
+  }
+  if (nrow(isPositive) == 0L) {
+    return(character())
+  }
+
+  tokenList <- lapply(seq_along(channels), function(i) {
+    paste0(channels[[i]], ifelse(isPositive[, i], "~+~", "~-~"))
+  })
+  do.call(paste0, tokenList)
+}
+
+.acsCytofCombinationCounts <- function(
+    xStim,
+    xUns,
+    thresholds,
+    channels = names(thresholds)) {
+  xStim <- as.matrix(xStim)
+  xUns <- as.matrix(xUns)
+  thresholds <- as.numeric(thresholds)
+
+  if (
+    ncol(xStim) != length(channels) ||
+      ncol(xUns) != length(channels) ||
+      length(thresholds) != length(channels)
+  ) {
+    stop("Expression matrices, thresholds and channels do not have matching widths.")
+  }
+  if (any(!is.finite(thresholds))) {
+    stop("All thresholds must be finite before combination counts are calculated.")
+  }
+
+  combinationLevels <- .acsCytofCombinationLevels(channels)
+  labelStim <- .acsCytofCombinationLabels(
+    sweep(xStim, 2L, thresholds, FUN = ">"),
+    channels = channels
+  )
+  labelUns <- .acsCytofCombinationLabels(
+    sweep(xUns, 2L, thresholds, FUN = ">"),
+    channels = channels
+  )
+
+  tibble::tibble(
+    cytCombn = combinationLevels,
+    countStim = as.integer(table(factor(labelStim, levels = combinationLevels))),
+    nCellStim = nrow(xStim),
+    countUns = as.integer(table(factor(labelUns, levels = combinationLevels))),
+    nCellUns = nrow(xUns)
+  )
+}
+
+.acsCytofExpressionMatrix <- function(gs, ind, channels) {
+  exprList <- lapply(channels, function(chnl) {
+    .acs_get_expr(gs = gs, ind = ind, chnl = chnl, pop = "root")
+  })
+  nCell <- lengths(exprList)
+  if (length(unique(nCell)) != 1L) {
+    stop("Cytokine channels returned different cell counts for sample index ", ind, ".")
+  }
+
+  out <- do.call(cbind, exprList)
+  colnames(out) <- channels
+  out
+}
+
+.acsCytofFallbackThreshold <- function(xStim, xUns, margin = 0.05) {
+  if (exists(".simCompareHighValueGate", mode = "function", inherits = TRUE)) {
+    return(.simCompareHighValueGate(
+      xStim = xStim,
+      xUns = xUns,
+      margin = margin
+    ))
+  }
+
+  x <- c(xStim, xUns)
+  x <- x[is.finite(x)]
+  if (length(x) == 0L) {
+    return(0)
+  }
+  rng <- range(x)
+  rng[[2]] + max(1, diff(rng)) * margin
+}
+
+.acsCytofThresholdOne <- function(
+    method,
+    xUns,
+    xStim,
+    settings,
+    pathFbeta = NULL) {
+  thresholdObj <- tryCatch(
+    {
+      if (identical(method, "fbeta")) {
+        if (!exists(
+          ".simCompareFbetaThreshold",
+          mode = "function",
+          inherits = TRUE
+        )) {
+          stop("Source scripts/r/sim-compare-freq_bs.R before running F-beta.")
+        }
+        do.call(
+          .simCompareFbetaThreshold,
+          c(
+            list(
+              xUns = xUns,
+              xStim = xStim,
+              pathFbeta = pathFbeta
+            ),
+            settings$params
+          )
+        )
+      } else {
+        if (!exists(
+          ".simCompareTailgateThreshold",
+          mode = "function",
+          inherits = TRUE
+        )) {
+          stop("Source scripts/r/sim-compare-freq_bs.R before running Tailgate.")
+        }
+        do.call(
+          .simCompareTailgateThreshold,
+          list(
+            x = xStim,
+            adjust = settings$params$adjust,
+            bandwidth = settings$params$bandwidth,
+            numPeaks = settings$params$numPeaks,
+            refPeak = settings$params$refPeak,
+            method = settings$params$derivativeMethod,
+            tol = settings$params$tol,
+            side = settings$params$side,
+            strict = settings$params$strict,
+            autoTol = settings$params$autoTol
+          )
+        )
+      }
+    },
+    error = function(e) {
+      list(
+        threshold = NA_real_,
+        thresholdMetric = NA_real_,
+        thresholdOrigin = paste0("error: ", conditionMessage(e))
+      )
+    }
+  )
+
+  thresholdRaw <- suppressWarnings(as.numeric(thresholdObj$threshold))[[1]]
+  fallbackUsed <- !is.finite(thresholdRaw)
+  threshold <- if (fallbackUsed) {
+    .acsCytofFallbackThreshold(xStim = xStim, xUns = xUns)
+  } else {
+    thresholdRaw
+  }
+
+  thresholdMetric <- thresholdObj$thresholdMetric
+  if (is.null(thresholdMetric) || length(thresholdMetric) == 0L) {
+    thresholdMetric <- NA_real_
+  }
+  thresholdOrigin <- thresholdObj$thresholdOrigin
+  if (is.null(thresholdOrigin) || length(thresholdOrigin) == 0L) {
+    thresholdOrigin <- "unknown"
+  }
+
+  tibble::tibble(
+    thresholdRaw = thresholdRaw,
+    threshold = threshold,
+    thresholdMetric = suppressWarnings(
+      as.numeric(thresholdMetric)
+    )[[1]],
+    thresholdOrigin = as.character(thresholdOrigin)[[1]],
+    thresholdFallbackUsed = fallbackUsed
+  )
+}
+
+.acsCytofRunComparator <- function(
+    gs,
+    pop,
+    method = c("tailgate", "fbeta"),
+    batchList = .acsCytofBatchList(length(gs)),
+    pathFbeta = NULL) {
+  method <- match.arg(method)
+  settings <- .acsCytofComparatorSettings(method)
+  channelMap <- settings$channelMap
+  channels <- names(channelMap)
+
+  resultList <- purrr::imap(batchList, function(indBatch, batchIndex) {
+    indUns <- indBatch[[1]]
+    xUns <- .acsCytofExpressionMatrix(
+      gs = gs,
+      ind = indUns,
+      channels = channels
+    )
+
+    purrr::map(indBatch[-1], function(indStim) {
+      xStim <- .acsCytofExpressionMatrix(
+        gs = gs,
+        ind = indStim,
+        channels = channels
+      )
+
+      thresholdTbl <- purrr::map_dfr(seq_along(channels), function(i) {
+        .acsCytofThresholdOne(
+          method = method,
+          xUns = xUns[, i],
+          xStim = xStim[, i],
+          settings = settings,
+          pathFbeta = pathFbeta
+        ) |>
+          dplyr::mutate(
+            method = .env$method,
+            pop = .env$pop,
+            batch = as.character(batchIndex),
+            ind = as.character(indStim),
+            indUns = as.character(indUns),
+            chnl = channels[[i]],
+            cyt = unname(channelMap[[i]]),
+            .before = 1L
+          )
+      })
+
+      thresholdVec <- stats::setNames(
+        thresholdTbl$threshold,
+        thresholdTbl$chnl
+      )
+      statsTbl <- .acsCytofCombinationCounts(
+        xStim = xStim,
+        xUns = xUns,
+        thresholds = thresholdVec[channels],
+        channels = channels
+      ) |>
+        dplyr::mutate(
+          gateName = .env$method,
+          method = .env$method,
+          pop = .env$pop,
+          batch = as.character(batchIndex),
+          ind = as.character(indStim),
+          indUns = as.character(indUns),
+          .before = 1L
+        ) |>
+        dplyr::mutate(
+          propStim = .data$countStim / .data$nCellStim,
+          propUns = .data$countUns / .data$nCellUns,
+          propBs = .data$propStim - .data$propUns,
+          freqStim = .data$propStim * 100,
+          freqUns = .data$propUns * 100,
+          freqBs = .data$freqStim - .data$freqUns
+        )
+
+      list(stats = statsTbl, thresholds = thresholdTbl)
+    })
+  }) |>
+    unlist(recursive = FALSE)
+
+  list(
+    settings = settings,
+    nSample = length(gs),
+    createdAt = Sys.time(),
+    stats = purrr::list_rbind(lapply(
+      resultList,
+      function(x) x[["stats"]]
+    )),
+    thresholds = purrr::list_rbind(lapply(
+      resultList,
+      function(x) x[["thresholds"]]
+    ))
+  )
+}
+
+.acsCytofCacheIsCurrent <- function(
+    object,
+    settings,
+    nSample = NULL) {
+  if (
+    !is.list(object) ||
+      !all(c("settings", "nSample", "stats", "thresholds") %in% names(object))
+  ) {
+    return(FALSE)
+  }
+  if (!isTRUE(all.equal(
+    object$settings,
+    settings,
+    check.attributes = FALSE
+  ))) {
+    return(FALSE)
+  }
+  if (
+    !is.null(nSample) &&
+      !identical(as.integer(object$nSample), as.integer(nSample))
+  ) {
+    return(FALSE)
+  }
+
+  requiredStats <- c(
+    "method", "pop", "ind", "cytCombn",
+    "countStim", "nCellStim", "countUns", "nCellUns"
+  )
+  requiredThresholds <- c(
+    "method", "pop", "ind", "chnl", "threshold",
+    "thresholdOrigin", "thresholdFallbackUsed"
+  )
+  all(requiredStats %in% names(object$stats)) &&
+    all(requiredThresholds %in% names(object$thresholds))
+}
+
+.acsCytofWriteComparatorCache <- function(object, path) {
+  if (exists(".write_rds_atomic", mode = "function", inherits = TRUE)) {
+    .write_rds_atomic(object, path)
+    return(invisible(path))
+  }
+
+  dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
+  pathTmp <- paste0(path, ".tmp-", Sys.getpid())
+  saveRDS(object, pathTmp)
+  if (!file.rename(pathTmp, path)) {
+    file.copy(pathTmp, path, overwrite = TRUE)
+    unlink(pathTmp)
+  }
+  invisible(path)
+}
+
+.acsCytofReadComparatorCache <- function(
+    path,
+    method,
+    nSample = NULL) {
+  if (!file.exists(path)) {
+    stop(
+      "Cached ", method, " result not found at: ", path,
+      ". Run the ACS comparison methods first."
+    )
+  }
+
+  object <- tryCatch(readRDS(path), error = function(e) NULL)
+  settings <- .acsCytofComparatorSettings(method)
+  if (!.acsCytofCacheIsCurrent(object, settings, nSample = nSample)) {
+    stop(
+      "Cached ", method, " result is missing, incomplete or was created ",
+      "with different settings. Re-run that ACS comparison method."
+    )
+  }
+  object
+}
+
+.acsCytofRunComparisonMethodsSafe <- function(...) {
+  pop <- list(...)$pop
+
+  tryCatch(
+    {
+      result <- .acsCytofRunComparisonMethods(...)
+      list(
+        pop = pop,
+        success = TRUE,
+        result = result,
+        error = NULL
+      )
+    },
+    error = function(e) {
+      list(
+        pop = pop,
+        success = FALSE,
+        result = NULL,
+        error = conditionMessage(e)
+      )
+    }
+  )
+}
+
+.acsCytofRunComparisonMethods <- function(
+    pop,
+    pathFcsBase,
+    pathGsBase,
+    pathScratchBase,
+    runMethods,
+    nSample = NULL,
+    outputGroup = NULL,
+    overwrite = FALSE,
+    pathFbeta = NULL) {
+  paths <- .acsCytofPopulationPaths(
+    pop = pop,
+    pathFcsBase = pathFcsBase,
+    pathGsBase = pathGsBase,
+    pathScratchBase = pathScratchBase,
+    outputGroup = outputGroup
+  )
+  methodVec <- c("tailgate", "fbeta")
+
+  if (!isTRUE(runMethods)) {
+    resultList <- lapply(methodVec, function(method) {
+      .acsCytofReadComparatorCache(
+        path = paths[[method]],
+        method = method,
+        nSample = nSample
+      )
+    })
+    names(resultList) <- methodVec
+    return(invisible(list(pop = pop, paths = paths, results = resultList)))
+  }
+
+  if (!dir.exists(paths$gs)) {
+    stop(
+      "Cached ACS CyTOF GatingSet not found for '",
+      pop,
+      "' at: ",
+      paths$gs,
+      ". Run preprocessing for this population first."
+    )
+  }
+  gs <- flowWorkspace::load_gs(paths$gs)
+  nSampleActual <- length(gs)
+  if (!is.null(nSample) && nSampleActual != nSample) {
+    stop(
+      "Cached tester GatingSet for '",
+      pop,
+      "' contains ",
+      nSampleActual,
+      " samples; expected ",
+      nSample,
+      ". Re-run tester preprocessing."
+    )
+  }
+  batchList <- .acsCytofBatchList(nSampleActual)
+
+  resultList <- lapply(methodVec, function(method) {
+    pathCache <- paths[[method]]
+    settings <- .acsCytofComparatorSettings(method)
+    if (file.exists(pathCache) && !isTRUE(overwrite)) {
+      cached <- tryCatch(readRDS(pathCache), error = function(e) NULL)
+      if (.acsCytofCacheIsCurrent(
+        cached,
+        settings = settings,
+        nSample = nSampleActual
+      )) {
+        message("Using cached ", method, " result for ", pop, ".")
+        return(cached)
+      }
+    }
+
+    message("Running ", method, " for ", pop, ".")
+    result <- .acsCytofRunComparator(
+      gs = gs,
+      pop = pop,
+      method = method,
+      batchList = batchList,
+      pathFbeta = pathFbeta
+    )
+    .acsCytofWriteComparatorCache(result, pathCache)
+    result
+  })
+  names(resultList) <- methodVec
+
+  invisible(list(
+    pop = pop,
+    nSample = nSampleActual,
+    batchList = batchList,
+    paths = paths,
+    results = resultList
+  ))
+}


### PR DESCRIPTION
## Summary

- run Tailgate and F-beta sequentially for the ACS CyTOF populations, using F-beta's standard settings and Tailgate's automatic bandwidth/tolerance tuning
- save one cache per method and population, including thresholds, fallback details and full six-marker combination counts, and reuse compatible caches on later renders
- reduce StimGate, Tailgate and F-beta combinations with `UtilsCytoRSV::sum_over_markers()`, normalise labels with `UtilsCompassSV::convert_cyt_combn_format()`, and join all three methods to the manual gates
- complete analysis 9's comparison tables and optional figures; keep `nk_pre` method output while excluding it from the manual join
- add focused analysis tests for settings, combination counts, cache validation, sequential execution and marker summation

## Checks

- `pandoc analysis/9-real-compare-acs-cytof.qmd -f markdown -t native`
- R analysis tests were not run locally because this workspace does not provide `Rscript`
- the data-dependent ACS runs were not executed in this workspace