### PR TITLE
Parallelise ACS comparator runs across populations

### DIFF
--- a/analysis/9-real-compare-acs-cytof.qmd
+++ b/analysis/9-real-compare-acs-cytof.qmd
@@ -278,28 +278,48 @@ if (isTRUE(run_stimgate)) {
 
 ## Tailgate and F-beta
 
-Tailgate and F-beta run one population at a time. Each method is saved
-immediately to its own `result.rds`; a later render reuses a complete cache when
-the sample count and fixed settings still match. Set
+Tailgate and F-beta run concurrently across populations, using the same
+`n_workers` control as StimGate. Within each population, the two methods remain
+sequential so that they do not compete for the same GatingSet. Each method is
+saved immediately to its own `result.rds`; a later render reuses a complete
+cache when the sample count and fixed settings still match. Set
 `overwrite_comparator_cache` to `true` only when those method outputs need to
 be recomputed.
 
 ```{r}
-#| label: run-comparison-methods-sequentially
+#| label: run-comparison-methods-in-parallel
 #| results: hide
 if (isTRUE(run_comparators)) {
-  comparison_method_runs <- purrr::map(
-    pop_vec,
-    function(pop) {
-      .acsCytofRunComparisonMethodsSafe(
-        pop = pop,
-        pathFcsBase = path_fcs_base,
-        pathGsBase = path_gs_base,
-        pathScratchBase = path_scratch_base,
-        runMethods = run_comparators_vec_by_pop[[pop]],
-        overwrite = overwrite_comparator_cache
+  n_comparator_workers_use <- min(n_workers, length(pop_vec))
+  old_comparator_plan <- future::plan()
+
+  comparison_method_runs <- tryCatch(
+    {
+      if (n_comparator_workers_use > 1L) {
+        future::plan(
+          future::multisession,
+          workers = n_comparator_workers_use
+        )
+      } else {
+        future::plan(future::sequential)
+      }
+
+      furrr::future_map(
+        pop_vec,
+        function(pop) {
+          .acsCytofRunComparisonMethodsSafe(
+            pop = pop,
+            pathFcsBase = path_fcs_base,
+            pathGsBase = path_gs_base,
+            pathScratchBase = path_scratch_base,
+            runMethods = run_comparators_vec_by_pop[[pop]],
+            overwrite = overwrite_comparator_cache
+          )
+        },
+        .options = furrr::furrr_options(seed = TRUE, scheduling = Inf)
       )
-    }
+    },
+    finally = future::plan(old_comparator_plan)
   )
   names(comparison_method_runs) <- pop_vec
 

--- a/analysis/tests/testthat/test-acs-cytof-methods.R
+++ b/analysis/tests/testthat/test-acs-cytof-methods.R
@@ -2,6 +2,7 @@ root_dir <- normalizePath(file.path(testthat::test_path(), "../../.."), mustWork
 script_gate <- file.path(root_dir, "scripts", "r", "acs_cytof-gate.R")
 script_methods <- file.path(root_dir, "scripts", "r", "acs_cytof-methods.R")
 script_manual <- file.path(root_dir, "scripts", "r", "acs_cytof-manual.R")
+qmd_path <- file.path(root_dir, "analysis", "9-real-compare-acs-cytof.qmd")
 
 .load_acs_method_env <- function() {
   env <- new.env(parent = getNamespace("stimgate"))
@@ -86,7 +87,7 @@ test_that("comparator cache validation includes settings and sample count", {
   expect_false(env$.acsCytofCacheIsCurrent(cache, changed_settings, nSample = 10L))
 })
 
-test_that("ACS comparison methods are deliberately sequential and cache each method", {
+test_that("ACS methods stay sequential within each population and cache results", {
   env <- .load_acs_method_env()
   runner_body <- paste(
     deparse(body(env$.acsCytofRunComparisonMethods)),
@@ -97,6 +98,39 @@ test_that("ACS comparison methods are deliberately sequential and cache each met
   expect_false(grepl("future_map", runner_body, fixed = TRUE))
   expect_true(grepl(".acsCytofWriteComparatorCache", runner_body, fixed = TRUE))
   expect_true(grepl("Using cached", runner_body, fixed = TRUE))
+})
+
+test_that("ACS comparator populations run in parallel", {
+  qmd_lines <- readLines(qmd_path, warn = FALSE)
+  chunk_start <- grep(
+    "#| label: run-comparison-methods-in-parallel",
+    qmd_lines,
+    fixed = TRUE
+  )
+  expect_length(chunk_start, 1L)
+
+  chunk_end_offset <- which(
+    qmd_lines[(chunk_start + 1L):length(qmd_lines)] == "```"
+  )[1L]
+  expect_false(is.na(chunk_end_offset))
+
+  chunk_lines <- qmd_lines[
+    chunk_start:(chunk_start + chunk_end_offset)
+  ]
+  chunk_body <- paste(chunk_lines, collapse = "\n")
+
+  expect_true(grepl("furrr::future_map", chunk_body, fixed = TRUE))
+  expect_true(grepl(
+    ".acsCytofRunComparisonMethodsSafe",
+    chunk_body,
+    fixed = TRUE
+  ))
+  expect_true(grepl("future::multisession", chunk_body, fixed = TRUE))
+  expect_true(grepl(
+    "finally = future::plan(old_comparator_plan)",
+    chunk_body,
+    fixed = TRUE
+  ))
 })
 
 test_that("manual formatting uses the shared cytometry combination utilities", {


### PR DESCRIPTION
## Summary

- run ACS Tailgate/F-beta comparator jobs concurrently across cell populations with `furrr::future_map()`
- use the existing `n_workers` / `ACS_N_WORKERS` control and restore the caller's future plan after the run
- keep Tailgate and F-beta sequential within each population, preserving their independent cached `result.rds` outputs
- add a targeted analysis regression test for population-level parallelism and future-plan restoration

## Validation

- Pandoc parse of the updated Quarto document
- static verification of the comparator chunk and regression assertions
- full R analysis tests deferred to CI because `Rscript` is unavailable in the workspace