### PR TITLE
Fix F-beta histogram support for stimulated response tails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,7 +395,15 @@ QMD runtime or unrelated plotting/orchestration code.
    Tailgate comparator functions are invoked directly from the `cytoUtils` package via
    `cytoUtils:::.cytokine_cutpoint()`. Do not reintroduce vendored legacy tailgate helpers
    under `scripts/r/` or `R/`.
-4. **Temporary migration status for `.getCpTg()` (issues #157/#158)**:
+4. **F-beta comparator provenance**:
+   `scripts/python/fbeta.py` is adapted from the Richards et al. (2014) positivity
+   threshold implementation. Preserve its F-beta scoring, standard parameters,
+   automatic bin count and moving-average smoothing. The deliberate StimGate-side
+   adaptation is that common histogram edges span both the stimulated and
+   unstimulated distributions; the published code derives them from the negative
+   distribution alone. Document any further deviation explicitly in the relevant
+   analyses and comparison issue.
+5. **Temporary migration status for `.getCpTg()` (issues #157/#158)**:
    This is a current-state note rather than a permanent design rule. Verify it against
    the current implementation and relevant issues before relying on it in later work.
    At the time of this update, remaining call sites are catalogued by
@@ -404,7 +412,7 @@ QMD runtime or unrelated plotting/orchestration code.
    `.gateBatchAll()`, but the current local-FDR cluster quantile implementation does
    not consume `gateTblCtrl`, so this branch is dead plumbing for current outputs.
    Single-positive gating branches have been removed per issue #196.
-5. **Simulation engine migration to `simcyto` (issues #288/#289/#291/#295 / umbrella #271)**:
+6. **Simulation engine migration to `simcyto` (issues #288/#289/#291/#295 / umbrella #271)**:
    Generic cytometry simulations, post-simulation transformations, and condition-mismatch
    controls are progressively migrating to the exported `simcyto` package API (e.g.
    `simcyto::simCytExperiment()`, `simcyto::simCytTransform*()`). `analysis/2-sim-bw-freq_bs-global.qmd`,
@@ -412,14 +420,14 @@ QMD runtime or unrelated plotting/orchestration code.
    `analysis/8-sim-compare-freq_bs-batch.qmd` use `simcyto` and do not source
    `functionsForBenchmarking-Cyt.R`. StimGate scientific scenario calculations, downstream
    comparison orchestration, and method evaluations remain StimGate-side under `scripts/r/`.
-6. **Standardised simulation and plotting controls across analysis QMDs (issue #299)**:
+7. **Standardised simulation and plotting controls across analysis QMDs (issue #299)**:
    All analysis QMDs follow a unified execution control pattern sourced from `scripts/r/analysis-runtime.R`:
    - YAML headers declare `params: run_simulations: true, run_plots: false` (along with any chunking parameters).
    - Setup chunks initialise `run_simulations` (defaulting to `FALSE` in interactive execution) and `run_plots` (defaulting to `TRUE` in interactive execution) via `.as_flag(.get_qmd_param_env(...))`.
    - Environment variables `RUN_SIMULATIONS` and `RUN_PLOTS` override YAML parameters and interactive default values.
    - Expensive simulation chunks are guarded with `if (isTRUE(run_simulations))`, and plotting chunks are guarded with `if (isTRUE(run_plots))`.
    - Collation chunks read cached output RDS files unconditionally so downstream summaries and diagnostics work whether simulations just ran or were loaded from cache.
-7. **Run-scoped staging, progress and promotion for expensive analysis simulations (issue #304)**:
+8. **Run-scoped staging, progress and promotion for expensive analysis simulations (issue #304)**:
    Expensive simulation analyses that support resumable per-scenario/per-chunk outputs must use shared run-management helpers from `scripts/r/analysis-runtime.R`:
    - Treat each logical run as a unique run ID (`analysis_run_id` QMD param or `ANALYSIS_RUN_ID` env var; auto-generated when absent).
    - Write run outputs to `cache/sim/<analysis-key>/staging/<YYYY-MM-DD>/<run-id>/...` and keep canonical outputs in `cache/sim/<analysis-key>/current/`.

--- a/analysis/7-sim-compare-freq_bs.qmd
+++ b/analysis/7-sim-compare-freq_bs.qmd
@@ -121,6 +121,12 @@ alternative thresholding approaches:
    `scripts/python/fbeta.py` via `reticulate`.
 2. `tailgate`, called from the `cytoUtils` package.
 
+The F-beta implementation retains the Richards et al. (2014) scoring procedure
+and standard parameters, but uses common histogram support spanning the paired
+stimulated and unstimulated distributions. The published code derives the bin
+range from the negative distribution alone, which can omit a simulated response
+tail beyond the observed negative range.
+
 For StimGate, bandwidth is estimated automatically using the ordinary `hpi1`
 selector, without background normalisation, with the bandwidth-estimation sample
 capped at 10,000 cells. Tailgate is deliberately left to use its usual automatic

--- a/analysis/8-sim-compare-freq_bs-batch.qmd
+++ b/analysis/8-sim-compare-freq_bs-batch.qmd
@@ -84,6 +84,11 @@ alternative thresholding approaches (`fbeta` and `tailgate`) under controlled
 **condition mismatch** (technical misalignment between the stimulated and
 matched unstimulated tubes).
 
+The F-beta implementation retains the Richards et al. (2014) scoring procedure
+and standard parameters, but adapts its histogram support to span both paired
+distributions. This prevents stimulated response-tail events outside the
+observed unstimulated range from being omitted from the F-beta calculation.
+
 The simulation isolates two deterministic post-transformation mismatch
 mechanisms provided by `simcyto`:
 

--- a/analysis/9-real-compare-acs-cytof.qmd
+++ b/analysis/9-real-compare-acs-cytof.qmd
@@ -166,6 +166,11 @@ StimGate flow is applied to every population configured in `pop_vec`.
 The reusable helpers fix the six cytokine channels and the method settings.
 StimGate uses `bwMtd = "hpi1"` and `gateCombn = "min"`. F-beta uses its standard
 parameters (`beta = 0.8`, `theta = 2`, `width = 10` and automatic bin count).
+The F-beta implementation is adapted from Richards et al. (2014) only in the
+histogram support: common bin edges span the matched stimulated and unstimulated
+distributions, instead of being derived from the unstimulated range alone. This
+prevents stimulated response-tail events outside the observed unstimulated range
+from being omitted when no explicit strong positive control is available.
 Tailgate uses the stimulated distribution, automatic bandwidth estimation and
 automatic tolerance tuning.
 

--- a/analysis/tests/testthat/test-acs-cytof-methods.R
+++ b/analysis/tests/testthat/test-acs-cytof-methods.R
@@ -2,6 +2,8 @@ root_dir <- normalizePath(file.path(testthat::test_path(), "../../.."), mustWork
 script_gate <- file.path(root_dir, "scripts", "r", "acs_cytof-gate.R")
 script_methods <- file.path(root_dir, "scripts", "r", "acs_cytof-methods.R")
 script_manual <- file.path(root_dir, "scripts", "r", "acs_cytof-manual.R")
+script_compare <- file.path(root_dir, "scripts", "r", "sim-compare-freq_bs.R")
+script_fbeta <- file.path(root_dir, "scripts", "python", "fbeta.py")
 qmd_path <- file.path(root_dir, "analysis", "9-real-compare-acs-cytof.qmd")
 
 .load_acs_method_env <- function() {
@@ -20,12 +22,37 @@ test_that("ACS comparator settings pin F-beta defaults and Tailgate auto tuning"
   expect_equal(fbeta$params$theta, 2)
   expect_equal(fbeta$params$width, 10L)
   expect_null(fbeta$params$numBins)
+  expect_equal(fbeta$cacheVersion, 2L)
 
   tailgate <- env$.acsCytofComparatorSettings("tailgate")
   expect_identical(tailgate$params$tailgateX, "stim")
   expect_null(tailgate$params$bandwidth)
   expect_true(tailgate$params$autoTol)
   expect_identical(tailgate$params$derivativeMethod, "firstDeriv")
+  expect_equal(tailgate$cacheVersion, 1L)
+})
+
+test_that("F-beta histogram support includes the stimulated response tail", {
+  skip_if_not_installed("reticulate")
+
+  env <- new.env(parent = getNamespace("stimgate"))
+  source(script_compare, local = env)
+
+  x_uns <- seq(0, 1, length.out = 400L)
+  x_stim <- c(seq(0, 1, length.out = 350L), rep(4, 50L))
+  out <- env$.simCompareFbetaThreshold(
+    xUns = x_uns,
+    xStim = x_stim,
+    pathFbeta = script_fbeta,
+    width = 2L,
+    numBins = 20L
+  )
+
+  expect_gt(max(as.numeric(out$fbeta$pdfx)), max(x_uns))
+  expect_gt(
+    max(as.numeric(out$fbeta$pdfx)),
+    max(x_stim) - diff(range(c(x_uns, x_stim))) / 20
+  )
 })
 
 test_that("thresholded cells are saved as a complete combination table", {

--- a/scripts/python/fbeta.py
+++ b/scripts/python/fbeta.py
@@ -1,3 +1,12 @@
+# Adapted from PositivityLib.py accompanying:
+# Richards et al. (2014), "Setting objective thresholds for rare event
+# detection in flow cytometry", Journal of Immunological Methods 409, 54-61.
+# https://doi.org/10.1016/j.jim.2014.04.002
+#
+# StimGate modification: histogram edges span the combined negative and
+# positive observations rather than the negative observations alone.  The
+# exact change is documented beside get_positivity_threshold().
+
 import os, sys, re
 import numpy as np
 import matplotlib as mpl
@@ -48,7 +57,13 @@ def get_positivity_threshold(neg,pos,channelIndex,beta=0.8,theta=2.0, width=10, 
     if numBins == None:
         numBins = int(np.sqrt(np.max([neg.shape[0],pos.shape[0]])))
 
-    pdfNeg, bins = np.histogram(neg, bins=numBins, normed=True)
+    # Richards et al. derive the histogram support from the negative sample.
+    # For the paired stim/unstim comparisons used here, that can discard the
+    # stimulated response tail when it extends beyond the observed unstimulated
+    # range.  Retain the published bin count and scoring procedure, but construct
+    # common bin edges over both samples so every event contributes to its pdf.
+    _, bins = np.histogram(np.concatenate([neg, pos]), bins=numBins)
+    pdfNeg, bins = np.histogram(neg, bins=bins, normed=True)
     pdfPos, bins = np.histogram(pos, bins=bins, normed=True)
 
     pdfNeg = move_mean(pdfNeg, window=width)

--- a/scripts/r/acs_cytof-methods.R
+++ b/scripts/r/acs_cytof-methods.R
@@ -36,7 +36,7 @@
   )
 
   list(
-    cacheVersion = 1L,
+    cacheVersion = if (identical(method, "fbeta")) 2L else 1L,
     method = method,
     channelMap = .acsCytofChannelMap(),
     params = params


### PR DESCRIPTION
## Summary

- Build F-beta histogram edges over the combined stimulated and matched unstimulated observations.
- Keep both histograms on those common edges so a stimulated response tail above the unstimulated maximum is retained.
- Preserve the Richards et al. F-beta score, threshold rule, smoothing, automatic bin count, and standard ACS parameters (`beta = 0.8`, `theta = 2`, `width = 10`).
- Increment only the F-beta ACS cache version from 1 to 2, so stale F-beta outputs are regenerated while Tailgate outputs remain reusable.
- Document the adaptation and its provenance in the implementation, analysis notebooks, and contributor guidance.
- Add regression coverage for a stimulated tail outside the unstimulated range.

## Why this adaptation is needed

The accompanying Richards et al. implementation constructs histogram bins from the negative sample and then applies those same bins to the positive sample. In the ACS data there is no dedicated PHA or SEB positive control, so F-beta must operate on each stimulated sample and its matched unstimulated sample. If a real stimulated response extends beyond the observed unstimulated maximum, the original histogram support omits that tail and renormalises the remaining stimulated distribution. This can produce degenerate thresholds and all-negative or all-positive classifications.

This PR changes only the histogram support. It does not introduce or infer a positive-control sample.

## Attribution and divergence from the reference code

The implementation is adapted from PositivityLib.py accompanying Richards et al., *Setting objective thresholds for rare event detection in flow cytometry*, Journal of Immunological Methods 409 (2014), 54–61, [doi:10.1016/j.jim.2014.04.002](https://doi.org/10.1016/j.jim.2014.04.002).

The exact divergence is:

```python
# Reference implementation
pdfNeg, bins = np.histogram(neg, bins=numBins, normed=True)

# StimGate adaptation
_, bins = np.histogram(np.concatenate([neg, pos]), bins=numBins)
pdfNeg, bins = np.histogram(neg, bins=bins, normed=True)
```

The positive histogram continues to use the same edges as the negative histogram. All subsequent smoothing and F-beta calculations are unchanged.

## Cache impact

Existing ACS F-beta `result.rds` files have cache version 1 and must be regenerated. F-beta now uses cache version 2. Tailgate remains at cache version 1.

## Validation

- `git diff --check`
- Numerical smoke test confirmed common support from 0.1 to 3.9 for an unstimulated range of 0 to 1 and a stimulated tail at 4, with a finite selected threshold of 1.5.
- Added an R regression test through the package's existing Reticulate wrapper.
- The full R test suite was not run in this environment because `Rscript` is unavailable.

Addresses the F-beta histogram-range component of #378.