### PR TITLE
Always rerun ACS comparators with worker-local F-beta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -402,7 +402,12 @@ QMD runtime or unrelated plotting/orchestration code.
    adaptation is that common histogram edges span both the stimulated and
    unstimulated distributions; the published code derives them from the negative
    distribution alone. Document any further deviation explicitly in the relevant
-   analyses and comparison issue.
+   analyses and comparison issue. Reticulate-backed Python environments must be
+   created inside the R process that uses them and kept local to that run; never
+   store them in a global R cache that can be serialised to multisession workers.
+   For the ACS analysis, requesting a Tailgate/F-beta run removes both prior
+   comparator `result.rds` files and recomputes them. Existing results are read only
+   when comparator execution is disabled.
 5. **Temporary migration status for `.getCpTg()` (issues #157/#158)**:
    This is a current-state note rather than a permanent design rule. Verify it against
    the current implementation and relevant issues before relying on it in later work.

--- a/analysis/9-real-compare-acs-cytof.qmd
+++ b/analysis/9-real-compare-acs-cytof.qmd
@@ -8,7 +8,6 @@ params:
   run_preprocessing: false
   run_stimgate: false
   run_comparators: true
-  overwrite_comparator_cache: true
   run_plots: true
   tester_n_sample: 20
   n_workers: 2
@@ -78,11 +77,6 @@ run_comparators_vec_by_pop <- c(
   nk_pre = NULL %||% run_comparators,
   b = NULL %||% run_comparators
 )
-overwrite_comparator_cache <- .as_flag(.get_qmd_param_env(
-  "overwrite_comparator_cache",
-  "OVERWRITE_COMPARATOR_CACHE",
-  TRUE
-))
 run_plots <- .as_flag(.get_qmd_param_env(
   "run_plots",
   "RUN_PLOTS",
@@ -150,6 +144,7 @@ path_scratch_base <- projr::projr_path_get(
   "acs_cytof",
   "scratch"
 )
+path_fbeta <- file.path(root_dir, "scripts", "python", "fbeta.py")
 ```
 
 ### Aim
@@ -205,7 +200,7 @@ tcrgd_comparison_tester <- .acsCytofRunComparisonMethods(
   runMethods = run_comparators,
   nSample = tester_n_sample,
   outputGroup = "tester",
-  overwrite = overwrite_comparator_cache
+  pathFbeta = path_fbeta
 )
 ```
 
@@ -282,10 +277,10 @@ if (isTRUE(run_stimgate)) {
 Tailgate and F-beta run concurrently across populations, using the same
 `n_workers` control as StimGate. Within each population, the two methods remain
 sequential so that they do not compete for the same GatingSet. Each method is
-saved immediately to its own `result.rds`; a later render reuses a complete
-cache when the sample count and fixed settings still match. Set
-`overwrite_comparator_cache` to `true` only when those method outputs need to
-be recomputed.
+saved immediately to its own `result.rds`. Whenever `run_comparators` is true,
+the previous F-beta and Tailgate results for that population are removed and
+both methods are recomputed. When `run_comparators` is false, existing results
+remain available to the downstream comparison and plotting sections.
 
 ```{r}
 #| label: run-comparison-methods-in-parallel
@@ -314,7 +309,7 @@ if (isTRUE(run_comparators)) {
             pathGsBase = path_gs_base,
             pathScratchBase = path_scratch_base,
             runMethods = run_comparators_vec_by_pop[[pop]],
-            overwrite = overwrite_comparator_cache
+            pathFbeta = path_fbeta
           )
         },
         .options = furrr::furrr_options(seed = TRUE, scheduling = Inf)

--- a/analysis/tests/testthat/test-acs-cytof-gate.R
+++ b/analysis/tests/testthat/test-acs-cytof-gate.R
@@ -92,7 +92,7 @@ test_that("analysis 9 uses one runner for the tester and configured populations"
     fixed = TRUE
   ))
   expect_true(grepl(
-    "run-comparison-methods-sequentially",
+    "run-comparison-methods-in-parallel",
     content,
     fixed = TRUE
   ))

--- a/analysis/tests/testthat/test-acs-cytof-methods.R
+++ b/analysis/tests/testthat/test-acs-cytof-methods.R
@@ -55,6 +55,56 @@ test_that("F-beta histogram support includes the stimulated response tail", {
   )
 })
 
+test_that("F-beta does not retain Python objects in a global R cache", {
+  skip_if_not_installed("reticulate")
+
+  env <- new.env(parent = getNamespace("stimgate"))
+  source(script_compare, local = env)
+
+  expect_false(exists(
+    ".simCompareCacheEnv",
+    envir = env,
+    inherits = FALSE
+  ))
+
+  fbeta_env <- env$.simCompareFbetaEnvironment(
+    pathFbeta = script_fbeta
+  )
+  out <- env$.simCompareFbetaThreshold(
+    xUns = seq(0, 1, length.out = 400L),
+    xStim = c(seq(0, 1, length.out = 350L), rep(4, 50L)),
+    pathFbeta = script_fbeta,
+    fbetaEnv = fbeta_env,
+    width = 2L,
+    numBins = 20L
+  )
+
+  expect_true(is.finite(out$threshold))
+  expect_false(exists(
+    ".simCompareCacheEnv",
+    envir = env,
+    inherits = FALSE
+  ))
+})
+
+test_that("comparator execution errors are not converted into fallback gates", {
+  env <- .load_acs_method_env()
+  env$.simCompareFbetaThreshold <- function(...) {
+    stop("reticulate worker failure")
+  }
+
+  expect_error(
+    env$.acsCytofThresholdOne(
+      method = "fbeta",
+      xUns = c(0, 1),
+      xStim = c(0, 2),
+      settings = env$.acsCytofComparatorSettings("fbeta"),
+      fbetaEnv = new.env(parent = emptyenv())
+    ),
+    "reticulate worker failure"
+  )
+})
+
 test_that("thresholded cells are saved as a complete combination table", {
   env <- .load_acs_method_env()
   channels <- c("A", "B")
@@ -114,7 +164,32 @@ test_that("comparator cache validation includes settings and sample count", {
   expect_false(env$.acsCytofCacheIsCurrent(cache, changed_settings, nSample = 10L))
 })
 
-test_that("ACS methods stay sequential within each population and cache results", {
+test_that("requested comparator runs remove both previous result files", {
+  env <- .load_acs_method_env()
+  path_dir <- tempfile("acs-comparator-results-")
+  dir.create(path_dir, recursive = TRUE)
+  withr::defer(unlink(path_dir, recursive = TRUE))
+
+  paths <- list(
+    fbeta = file.path(path_dir, "fbeta", "result.rds"),
+    tailgate = file.path(path_dir, "tailgate", "result.rds"),
+    gs = file.path(path_dir, "gs")
+  )
+  dir.create(dirname(paths$fbeta), recursive = TRUE)
+  dir.create(dirname(paths$tailgate), recursive = TRUE)
+  saveRDS("old fbeta", paths$fbeta)
+  saveRDS("old tailgate", paths$tailgate)
+  writeLines("keep", paths$gs)
+
+  removed <- env$.acsCytofRemoveComparatorResults(paths)
+
+  expect_setequal(removed, c(paths$fbeta, paths$tailgate))
+  expect_false(file.exists(paths$fbeta))
+  expect_false(file.exists(paths$tailgate))
+  expect_true(file.exists(paths$gs))
+})
+
+test_that("ACS methods stay sequential and always replace previous results", {
   env <- .load_acs_method_env()
   runner_body <- paste(
     deparse(body(env$.acsCytofRunComparisonMethods)),
@@ -124,11 +199,24 @@ test_that("ACS methods stay sequential within each population and cache results"
   expect_true(grepl("lapply(methodVec", runner_body, fixed = TRUE))
   expect_false(grepl("future_map", runner_body, fixed = TRUE))
   expect_true(grepl(".acsCytofWriteComparatorCache", runner_body, fixed = TRUE))
-  expect_true(grepl("Using cached", runner_body, fixed = TRUE))
+  expect_true(grepl(
+    ".acsCytofRemoveComparatorResults",
+    runner_body,
+    fixed = TRUE
+  ))
+  expect_false(grepl("Using cached", runner_body, fixed = TRUE))
+  expect_false("overwrite" %in% names(formals(
+    env$.acsCytofRunComparisonMethods
+  )))
 })
 
 test_that("ACS comparator populations run in parallel", {
   qmd_lines <- readLines(qmd_path, warn = FALSE)
+  expect_false(any(grepl(
+    "overwrite_comparator_cache",
+    qmd_lines,
+    fixed = TRUE
+  )))
   chunk_start <- grep(
     "#| label: run-comparison-methods-in-parallel",
     qmd_lines,
@@ -153,6 +241,7 @@ test_that("ACS comparator populations run in parallel", {
     fixed = TRUE
   ))
   expect_true(grepl("future::multisession", chunk_body, fixed = TRUE))
+  expect_true(grepl("pathFbeta = path_fbeta", chunk_body, fixed = TRUE))
   expect_true(grepl(
     "finally = future::plan(old_comparator_plan)",
     chunk_body,

--- a/scripts/r/acs_cytof-methods.R
+++ b/scripts/r/acs_cytof-methods.R
@@ -165,68 +165,59 @@
   xUns,
   xStim,
   settings,
-  pathFbeta = NULL
+  pathFbeta = NULL,
+  fbetaEnv = NULL
 ) {
-  thresholdObj <- tryCatch(
-    {
-      if (identical(method, "fbeta")) {
-        if (
-          !exists(
-            ".simCompareFbetaThreshold",
-            mode = "function",
-            inherits = TRUE
-          )
-        ) {
-          stop("Source scripts/r/sim-compare-freq_bs.R before running F-beta.")
-        }
-        do.call(
-          .simCompareFbetaThreshold,
-          c(
-            list(
-              xUns = xUns,
-              xStim = xStim,
-              pathFbeta = pathFbeta
-            ),
-            settings$params
-          )
-        )
-      } else {
-        if (
-          !exists(
-            ".simCompareTailgateThreshold",
-            mode = "function",
-            inherits = TRUE
-          )
-        ) {
-          stop(
-            "Source scripts/r/sim-compare-freq_bs.R before running Tailgate."
-          )
-        }
-        do.call(
-          .simCompareTailgateThreshold,
-          list(
-            x = xStim,
-            adjust = settings$params$adjust,
-            bandwidth = settings$params$bandwidth,
-            numPeaks = settings$params$numPeaks,
-            refPeak = settings$params$refPeak,
-            method = settings$params$derivativeMethod,
-            tol = settings$params$tol,
-            side = settings$params$side,
-            strict = settings$params$strict,
-            autoTol = settings$params$autoTol
-          )
-        )
-      }
-    },
-    error = function(e) {
-      list(
-        threshold = NA_real_,
-        thresholdMetric = NA_real_,
-        thresholdOrigin = paste0("error: ", conditionMessage(e))
+  thresholdObj <- if (identical(method, "fbeta")) {
+    if (
+      !exists(
+        ".simCompareFbetaThreshold",
+        mode = "function",
+        inherits = TRUE
+      )
+    ) {
+      stop("Source scripts/r/sim-compare-freq_bs.R before running F-beta.")
+    }
+    do.call(
+      .simCompareFbetaThreshold,
+      c(
+        list(
+          xUns = xUns,
+          xStim = xStim,
+          pathFbeta = pathFbeta,
+          fbetaEnv = fbetaEnv
+        ),
+        settings$params
+      )
+    )
+  } else {
+    if (
+      !exists(
+        ".simCompareTailgateThreshold",
+        mode = "function",
+        inherits = TRUE
+      )
+    ) {
+      stop(
+        "Source scripts/r/sim-compare-freq_bs.R before running Tailgate."
       )
     }
-  )
+    do.call(
+      .simCompareTailgateThreshold,
+      list(
+        x = xStim,
+        adjust = settings$params$adjust,
+        bandwidth = settings$params$bandwidth,
+        numPeaks = settings$params$numPeaks,
+        refPeak = settings$params$refPeak,
+        method = settings$params$derivativeMethod,
+        tol = settings$params$tol,
+        side = settings$params$side,
+        strict = settings$params$strict,
+        autoTol = settings$params$autoTol
+      )
+    )
+  }
 
   thresholdRaw <- suppressWarnings(as.numeric(thresholdObj$threshold))[[1]]
   fallbackUsed <- !is.finite(thresholdRaw)
@@ -267,6 +258,23 @@
   settings <- .acsCytofComparatorSettings(method)
   channelMap <- settings$channelMap
   channels <- names(channelMap)
+  fbetaEnv <- if (identical(method, "fbeta")) {
+    if (
+      !exists(
+        ".simCompareFbetaEnvironment",
+        mode = "function",
+        inherits = TRUE
+      )
+    ) {
+      stop("Source scripts/r/sim-compare-freq_bs.R before running F-beta.")
+    }
+    .simCompareFbetaEnvironment(
+      pathFbeta = pathFbeta,
+      patchPy2Compat = settings$params$patchPy2Compat
+    )
+  } else {
+    NULL
+  }
 
   resultList <- purrr::imap(batchList, function(indBatch, batchIndex) {
     indUns <- indBatch[[1]]
@@ -289,7 +297,8 @@
           xUns = xUns[, i],
           xStim = xStim[, i],
           settings = settings,
-          pathFbeta = pathFbeta
+          pathFbeta = pathFbeta,
+          fbetaEnv = fbetaEnv
         ) |>
           dplyr::mutate(
             method = .env$method,
@@ -417,6 +426,28 @@
   invisible(path)
 }
 
+.acsCytofRemoveComparatorResults <- function(
+  paths,
+  methods = c("fbeta", "tailgate")
+) {
+  pathResultVec <- unname(unlist(paths[methods], use.names = FALSE))
+  pathResultVec <- pathResultVec[file.exists(pathResultVec)]
+  if (length(pathResultVec) == 0L) {
+    return(invisible(character()))
+  }
+
+  unlink(pathResultVec)
+  pathRemaining <- pathResultVec[file.exists(pathResultVec)]
+  if (length(pathRemaining) > 0L) {
+    stop(
+      "Could not remove previous comparator result(s): ",
+      paste(pathRemaining, collapse = ", ")
+    )
+  }
+
+  invisible(pathResultVec)
+}
+
 .acsCytofReadComparatorCache <- function(
   path,
   method,
@@ -477,7 +508,6 @@
   runMethods,
   nSample = NULL,
   outputGroup = NULL,
-  overwrite = FALSE,
   pathFbeta = NULL
 ) {
   paths <- .acsCytofPopulationPaths(
@@ -525,23 +555,9 @@
   }
   batchList <- .acsCytofBatchList(nSampleActual)
 
-  resultList <- lapply(methodVec, function(method) {
-    pathCache <- paths[[method]]
-    settings <- .acsCytofComparatorSettings(method)
-    if (file.exists(pathCache) && !isTRUE(overwrite)) {
-      cached <- tryCatch(readRDS(pathCache), error = function(e) NULL)
-      if (
-        .acsCytofCacheIsCurrent(
-          cached,
-          settings = settings,
-          nSample = nSampleActual
-        )
-      ) {
-        message("Using cached ", method, " result for ", pop, ".")
-        return(cached)
-      }
-    }
+  .acsCytofRemoveComparatorResults(paths = paths, methods = methodVec)
 
+  resultList <- lapply(methodVec, function(method) {
     message("Running ", method, " for ", pop, ".")
     result <- .acsCytofRunComparator(
       gs = gs,
@@ -550,7 +566,7 @@
       batchList = batchList,
       pathFbeta = pathFbeta
     )
-    .acsCytofWriteComparatorCache(result, pathCache)
+    .acsCytofWriteComparatorCache(result, paths[[method]])
     result
   })
   names(resultList) <- methodVec

--- a/scripts/r/sim-compare-freq_bs.R
+++ b/scripts/r/sim-compare-freq_bs.R
@@ -1,5 +1,3 @@
-.simCompareCacheEnv <- new.env(parent = emptyenv())
-
 #' @keywords internal
 .simCompareAddMissingColumns <- function(.data, cols) {
   for (nm in names(cols)) {
@@ -183,6 +181,36 @@
   pathTmp
 }
 
+#' Load the fbeta Python implementation for one R run
+#'
+#' The returned environment contains Reticulate-backed Python objects and must
+#' remain local to the R process that created it. In particular, it must not be
+#' stored in a global cache that can be serialised to multisession workers.
+#'
+#' @keywords internal
+.simCompareFbetaEnvironment <- function(
+    pathFbeta = NULL,
+    patchPy2Compat = TRUE) {
+  if (!requireNamespace("reticulate", quietly = TRUE)) {
+    stop("reticulate is required to call fbeta.py.")
+  }
+
+  pathFbeta <- .simCompareFbetaPath(pathFbeta)
+  pathPyUse <- .simCompareFbetaCompatPath(
+    pathFbeta = pathFbeta,
+    patchPy2Compat = patchPy2Compat
+  )
+
+  pyEnv <- new.env(parent = emptyenv())
+  reticulate::source_python(pathPyUse, envir = pyEnv)
+
+  if (!exists("get_positivity_threshold", envir = pyEnv, inherits = FALSE)) {
+    stop("fbeta.py did not define get_positivity_threshold().")
+  }
+
+  pyEnv
+}
+
 #' Call the fbeta Python implementation via reticulate
 #'
 #' @keywords internal
@@ -191,6 +219,7 @@
     xStim,
     pathFbeta = NULL,
     patchPy2Compat = TRUE,
+    fbetaEnv = NULL,
     beta = 0.8,
     theta = 2,
     width = 10,
@@ -212,38 +241,17 @@
     ))
   }
 
-  pathFbeta <- .simCompareFbetaPath(pathFbeta)
-  pathInfo <- file.info(pathFbeta)
-  cacheName <- make.names(paste(
-    "fbeta",
-    normalizePath(pathFbeta, winslash = "/", mustWork = FALSE),
-    patchPy2Compat,
-    pathInfo$mtime,
-    sep = "_"
-  ))
-
-  if (!exists(cacheName, envir = .simCompareCacheEnv, inherits = FALSE)) {
-    pathPyUse <- .simCompareFbetaCompatPath(
+  if (is.null(fbetaEnv)) {
+    fbetaEnv <- .simCompareFbetaEnvironment(
       pathFbeta = pathFbeta,
       patchPy2Compat = patchPy2Compat
     )
-
-    pyEnv <- new.env(parent = emptyenv())
-    reticulate::source_python(pathPyUse, envir = pyEnv)
-
-    if (!exists("get_positivity_threshold", envir = pyEnv, inherits = FALSE)) {
-      stop("fbeta.py did not define get_positivity_threshold().")
-    }
-
-    assign(cacheName, pyEnv, envir = .simCompareCacheEnv)
   }
-
-  pyEnv <- get(cacheName, envir = .simCompareCacheEnv, inherits = FALSE)
 
   negMat <- matrix(xUns, ncol = 1L)
   posMat <- matrix(xStim, ncol = 1L)
 
-  out <- pyEnv$get_positivity_threshold(
+  out <- fbetaEnv$get_positivity_threshold(
     neg = negMat,
     pos = posMat,
     channelIndex = 0L,
@@ -600,6 +608,11 @@
   tailgateX <- match.arg(tailgateX)
   tailgateMethod <- match.arg(tailgateMethod)
 
+  fbetaEnv <- .simCompareFbetaEnvironment(
+    pathFbeta = pathFbeta,
+    patchPy2Compat = fbetaPatchPy2Compat
+  )
+
   truthTbl <- .simCompareTruthTable(
     labelsList = labelsList,
     nSample = nSample,
@@ -625,6 +638,7 @@
           xStim = xStim,
           pathFbeta = pathFbeta,
           patchPy2Compat = fbetaPatchPy2Compat,
+          fbetaEnv = fbetaEnv,
           beta = fbetaBeta,
           theta = fbetaTheta,
           width = fbetaWidth,


### PR DESCRIPTION
## Summary

- Remove conditional reuse of ACS Tailgate and F-beta result files.
- Whenever comparator execution is requested for a population, remove both existing comparator `result.rds` files before recomputing either method.
- Keep existing results readable when comparator execution is disabled, so plotting-only renders still work.
- Load the F-beta Python implementation once per comparator run inside the R process that uses it, instead of storing Reticulate-backed objects in a global R cache.
- Pass the F-beta script path explicitly into tester and population runs.
- Let comparator execution errors fail the population run rather than silently converting them into high fallback gates and all-negative output.

## Cause of the all-zero F-beta run

The TCRγδ tester loaded `fbeta.py` in the main R process and stored its Python functions in `.simCompareCacheEnv`. The subsequent `future::multisession` population loop serialised that environment into workers. Those workers received Reticulate objects owned by the previous R session, causing every threshold calculation to fail with:

```text
Unable to access object (object is from previous session ...)
```

The ACS wrapper then converted each error into a high fallback threshold, yielding all-negative combination counts. The new run-local Python environment is created inside each worker and never crosses a process boundary.

## Result lifecycle

`run_comparators = true` now has one unambiguous meaning: discard the previous F-beta and Tailgate results for each requested population and write fresh results. The `overwrite_comparator_cache` parameter and environment variable have been removed.

`run_comparators = false` does not delete anything; existing results remain available to downstream read/plot code.

## Validation

- Added regression coverage that both old comparator results are removed while unrelated files remain.
- Added coverage that no global Reticulate environment cache is retained.
- Added coverage that execution errors propagate instead of becoming fallback gates.
- Updated analysis 9 integration checks for explicit F-beta path forwarding and the current parallel chunk label.
- `git diff --check` passes.
- The R test suite could not be run locally because this execution environment has no `Rscript`; CI is expected to run the analysis integration suite.

Follow-up to #380. Addresses the parallel F-beta failure reported under #378.