### PR TITLE
Add ACS manual-validation figures for StimGate and comparators

### DIFF
--- a/analysis/9-real-compare-acs-cytof-validation.qmd
+++ b/analysis/9-real-compare-acs-cytof-validation.qmd
@@ -1,0 +1,127 @@
+---
+title: ACS CyTOF validation outputs
+format:
+  html:
+    embed-resources: true
+    toc: true
+params:
+  run_plots: true
+---
+
+```{r}
+#| label: setup
+#| include: false
+library(ggplot2)
+library(dplyr)
+
+root_dir <- tryCatch(
+  projr::projr_path_get("project"),
+  error = function(e) getwd()
+)
+scripts_r_dir <- file.path(root_dir, "scripts", "r")
+source(file.path(scripts_r_dir, "acs_cytof-plot_cyt.R"))
+
+run_plots <- isTRUE(params$run_plots)
+path_manual_output <- projr::projr_path_get(
+  "cache",
+  "acs_cytof",
+  "manual-comparison"
+)
+path_comparison <- file.path(path_manual_output, "manual-comparison.rds")
+if (!file.exists(path_comparison)) {
+  stop(
+    "ACS manual comparison table not found at: ",
+    path_comparison,
+    ". Run analysis/9-real-compare-acs-cytof.qmd first."
+  )
+}
+manual_comparison_tbl <- readRDS(path_comparison)
+```
+
+## Aim
+
+Reproduce the ACS manuscript-style validation plots for StimGate, F-beta and
+Tailgate using the comparison table produced by the main ACS analysis.
+
+The raw-frequency plots show automated against manual background-subtracted
+frequencies for every matched population and cytokine. The correlation outputs
+show both Pearson correlation (PCC) and concordance correlation (CCC), with one
+set restricted to CD4, CD8 and TCRgd T cells and another using every matched
+population. This keeps the original manuscript comparison available while also
+showing the additional populations in the current benchmark.
+
+## Correlation table
+
+```{r}
+#| label: correlation-table
+correlation_tbl <- .acsCytofValidationCorrelationTable(manual_comparison_tbl)
+correlation_tbl
+```
+
+## Validation figures
+
+```{r}
+#| label: save-validation-figures
+#| results: hide
+if (run_plots) {
+  .acsCytofValidationSavePlots(
+    comparisonTbl = manual_comparison_tbl,
+    pathDirSave = path_manual_output
+  )
+}
+```
+
+### Raw background-subtracted frequencies
+
+```{r}
+#| label: show-scatter
+if (run_plots) {
+  .acsCytofValidationPlotScatter(manual_comparison_tbl, "stimgate")
+  .acsCytofValidationPlotScatter(manual_comparison_tbl, "fbeta")
+  .acsCytofValidationPlotScatter(manual_comparison_tbl, "tailgate")
+}
+```
+
+### Correlation heatmaps for CD4, CD8 and TCRgd T cells
+
+```{r}
+#| label: show-real-pop-heatmaps
+if (run_plots) {
+  for (method in c("stimgate", "fbeta", "tailgate")) {
+    print(.acsCytofValidationPlotCorrelation(
+      correlationTbl = correlation_tbl,
+      method = method,
+      metric = "pcc",
+      realPopulationsOnly = TRUE
+    ))
+    print(.acsCytofValidationPlotCorrelation(
+      correlationTbl = correlation_tbl,
+      method = method,
+      metric = "ccc",
+      realPopulationsOnly = TRUE
+    ))
+  }
+}
+```
+
+### Correlation heatmaps for all matched populations
+
+```{r}
+#| label: show-all-pop-heatmaps
+if (run_plots) {
+  for (method in c("stimgate", "fbeta", "tailgate")) {
+    print(.acsCytofValidationPlotCorrelation(
+      correlationTbl = correlation_tbl,
+      method = method,
+      metric = "pcc",
+      realPopulationsOnly = FALSE
+    ))
+    print(.acsCytofValidationPlotCorrelation(
+      correlationTbl = correlation_tbl,
+      method = method,
+      metric = "ccc",
+      realPopulationsOnly = FALSE
+    ))
+  }
+}
+```

--- a/analysis/tests/testthat/test-acs-cytof-validation-plots.R
+++ b/analysis/tests/testthat/test-acs-cytof-validation-plots.R
@@ -1,0 +1,60 @@
+root_dir <- normalizePath(
+  file.path(testthat::test_path(), "../../.."),
+  mustWork = TRUE
+)
+script_plot <- file.path(root_dir, "scripts", "r", "acs_cytof-plot_cyt.R")
+
+env <- new.env(parent = getNamespace("stimgate"))
+source(script_plot, local = env)
+
+.acs_validation_fixture <- function() {
+  tidyr::expand_grid(
+    method = c("stimgate", "fbeta", "tailgate"),
+    pop = c("CD4 T cells", "B cells"),
+    cyt = c("IFNg", "IL2"),
+    stim = c("p1", "mtb", "ebv", "p4"),
+    SampleID = paste0("sample", 1:4)
+  ) |>
+    dplyr::group_by(method, pop, cyt, stim) |>
+    dplyr::mutate(
+      freq_bs_man = seq(0.1, 0.4, length.out = dplyr::n()),
+      freq_bs_auto = .data$freq_bs_man * 1.1,
+      freq_stim_man = .data$freq_bs_man + 0.02,
+      freq_uns_man = 0.02
+    ) |>
+    dplyr::ungroup()
+}
+
+test_that("CCC is one for identical vectors", {
+  expect_equal(env$.acsCytofValidationCcc(1:5, 1:5), 1)
+  expect_true(is.na(env$.acsCytofValidationCcc(rep(1, 5), 1:5)))
+})
+
+test_that("correlation table contains PCC and CCC by method and stratum", {
+  comparison_tbl <- .acs_validation_fixture()
+  correlation_tbl <- env$.acsCytofValidationCorrelationTable(comparison_tbl)
+
+  expect_true(all(c("method", "pop", "cyt", "stim", "pcc", "ccc") %in%
+    names(correlation_tbl)))
+  expect_equal(nrow(correlation_tbl), 3 * 2 * 2 * 4)
+  expect_true(all(abs(correlation_tbl$pcc - 1) < 1e-10))
+})
+
+test_that("validation plotting helpers return ggplot objects", {
+  comparison_tbl <- .acs_validation_fixture()
+  correlation_tbl <- env$.acsCytofValidationCorrelationTable(comparison_tbl)
+
+  expect_s3_class(
+    env$.acsCytofValidationPlotScatter(comparison_tbl, "stimgate"),
+    "ggplot"
+  )
+  expect_s3_class(
+    env$.acsCytofValidationPlotCorrelation(
+      correlation_tbl,
+      method = "stimgate",
+      metric = "ccc",
+      realPopulationsOnly = TRUE
+    ),
+    "ggplot"
+  )
+})

--- a/scripts/r/acs_cytof-plot_cyt.R
+++ b/scripts/r/acs_cytof-plot_cyt.R
@@ -1,0 +1,255 @@
+.acsCytofValidationStimColours <- function() {
+  c(
+    mtb = "#e34234",
+    p1 = "#40826d",
+    p4 = "#ff00ff",
+    ebv = "#7700cf"
+  )
+}
+
+.acsCytofValidationStimLabels <- function() {
+  c(
+    mtb = "Live Mtb",
+    p1 = "Secreted Mtb proteins",
+    ebv = "EBV and CMV",
+    p4 = "Non-secreted Mtb proteins"
+  )
+}
+
+.acsCytofValidationMethodLabels <- function() {
+  c(
+    stimgate = "StimGate",
+    fbeta = "F-beta",
+    tailgate = "Tailgate"
+  )
+}
+
+.acsCytofValidationRealPopulations <- function() {
+  c("CD4 T cells", "CD8 T cells", "TCRgd T cells")
+}
+
+.acsCytofValidationCcc <- function(x, y) {
+  complete <- stats::complete.cases(x, y)
+  x <- x[complete]
+  y <- y[complete]
+  if (length(x) < 2L || stats::sd(x) == 0 || stats::sd(y) == 0) {
+    return(NA_real_)
+  }
+
+  covariance <- stats::cov(x, y)
+  (2 * covariance) /
+    (stats::var(x) + stats::var(y) + (mean(x) - mean(y))^2)
+}
+
+.acsCytofValidationCorrelationTable <- function(comparisonTbl) {
+  comparisonTbl |>
+    dplyr::group_by(method, pop, cyt, stim) |>
+    dplyr::summarise(
+      n = sum(stats::complete.cases(.data$freq_bs_auto, .data$freq_bs_man)),
+      pcc = if (n > 1L) {
+        suppressWarnings(stats::cor(
+          .data$freq_bs_auto,
+          .data$freq_bs_man,
+          use = "complete.obs"
+        ))
+      } else {
+        NA_real_
+      },
+      ccc = .acsCytofValidationCcc(
+        .data$freq_bs_auto,
+        .data$freq_bs_man
+      ),
+      .groups = "drop"
+    )
+}
+
+.acsCytofValidationPlotScatter <- function(comparisonTbl, method) {
+  method <- match.arg(method, c("stimgate", "fbeta", "tailgate"))
+  plotTbl <- comparisonTbl |>
+    dplyr::filter(.data$method == .env$method) |>
+    dplyr::mutate(
+      cyt = factor(
+        .data$cyt,
+        levels = c("IFNg", "IL2", "TNF", "IL17", "IL22", "IL6")
+      ),
+      pop = factor(
+        .data$pop,
+        levels = c(
+          "CD4 T cells",
+          "CD8 T cells",
+          "TCRgd T cells",
+          "B cells",
+          "NK cells"
+        )
+      )
+    )
+
+  ggplot2::ggplot(plotTbl) +
+    cowplot::theme_cowplot() +
+    ggplot2::theme(
+      plot.background = ggplot2::element_rect(fill = "white"),
+      panel.background = ggplot2::element_rect(fill = "white")
+    ) +
+    cowplot::background_grid(major = "xy") +
+    ggplot2::geom_vline(xintercept = 0) +
+    ggplot2::geom_hline(yintercept = 0) +
+    ggplot2::geom_abline(intercept = 0, slope = 1) +
+    ggplot2::geom_point(
+      ggplot2::aes(
+        x = .data$freq_bs_man,
+        y = .data$freq_bs_auto,
+        colour = .data$stim
+      )
+    ) +
+    ggplot2::facet_wrap(
+      ggplot2::vars(pop, cyt),
+      scales = "free",
+      ncol = dplyr::n_distinct(plotTbl$cyt)
+    ) +
+    ggplot2::scale_colour_manual(
+      values = .acsCytofValidationStimColours(),
+      labels = .acsCytofValidationStimLabels()
+    ) +
+    ggplot2::labs(
+      title = unname(.acsCytofValidationMethodLabels()[[method]]),
+      x = "Background-subtracted frequency\n(manual gating)",
+      y = "Background-subtracted frequency\n(automated gating)",
+      colour = NULL
+    ) +
+    ggplot2::theme(
+      legend.position = "bottom",
+      legend.justification = "center"
+    )
+}
+
+.acsCytofValidationPlotCorrelation <- function(
+  correlationTbl,
+  method,
+  metric = c("pcc", "ccc"),
+  realPopulationsOnly = TRUE
+) {
+  metric <- match.arg(metric)
+  method <- match.arg(method, c("stimgate", "fbeta", "tailgate"))
+  plotTbl <- correlationTbl |>
+    dplyr::filter(
+      .data$method == .env$method,
+      .data$stim != "p4"
+    )
+  if (isTRUE(realPopulationsOnly)) {
+    plotTbl <- plotTbl |>
+      dplyr::filter(.data$pop %in% .acsCytofValidationRealPopulations())
+  }
+
+  plotTbl <- plotTbl |>
+    dplyr::mutate(
+      cyt = factor(
+        .data$cyt,
+        levels = c("IFNg", "IL2", "TNF", "IL17", "IL22", "IL6")
+      ),
+      pop = factor(
+        .data$pop,
+        levels = c(
+          "CD4 T cells",
+          "CD8 T cells",
+          "TCRgd T cells",
+          "B cells",
+          "NK cells"
+        )
+      ),
+      stim = factor(
+        .data$stim,
+        levels = c("p1", "mtb", "ebv"),
+        labels = .acsCytofValidationStimLabels()[c("p1", "mtb", "ebv")]
+      )
+    )
+
+  metricLabel <- if (metric == "pcc") {
+    "Pearson correlation"
+  } else {
+    "Concordance correlation"
+  }
+  colourValues <- rev(RColorBrewer::brewer.pal(11, "RdBu"))
+
+  ggplot2::ggplot(
+    plotTbl,
+    ggplot2::aes(x = .data$cyt, y = .data$pop)
+  ) +
+    cowplot::theme_cowplot() +
+    ggplot2::geom_raster(ggplot2::aes(fill = .data[[metric]])) +
+    ggplot2::geom_text(
+      ggplot2::aes(label = round(.data[[metric]], 2)),
+      size = 2.25
+    ) +
+    ggplot2::facet_wrap(ggplot2::vars(stim), ncol = 3, scales = "fixed") +
+    ggplot2::scale_fill_gradientn(
+      colours = colourValues,
+      values = seq(0, 1, length.out = length(colourValues)),
+      limits = c(-1, 1),
+      na.value = "gray75",
+      name = metricLabel
+    ) +
+    ggplot2::labs(
+      title = unname(.acsCytofValidationMethodLabels()[[method]]),
+      x = "Cytokine",
+      y = "Population"
+    ) +
+    ggplot2::theme(
+      axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust = 1),
+      strip.background = ggplot2::element_rect(fill = "white", colour = "black"),
+      strip.text = ggplot2::element_text(size = 9.5),
+      legend.title = ggplot2::element_text(size = 10)
+    )
+}
+
+.acsCytofValidationSavePlots <- function(comparisonTbl, pathDirSave) {
+  dir.create(pathDirSave, recursive = TRUE, showWarnings = FALSE)
+  correlationTbl <- .acsCytofValidationCorrelationTable(comparisonTbl)
+  utils::write.csv(
+    correlationTbl,
+    file.path(pathDirSave, "manual-comparison-correlations.csv"),
+    row.names = FALSE
+  )
+  saveRDS(
+    correlationTbl,
+    file.path(pathDirSave, "manual-comparison-correlations.rds")
+  )
+
+  methods <- intersect(
+    c("stimgate", "fbeta", "tailgate"),
+    as.character(unique(comparisonTbl$method))
+  )
+  for (method in methods) {
+    scatter <- .acsCytofValidationPlotScatter(comparisonTbl, method)
+    ggplot2::ggsave(
+      file.path(pathDirSave, paste0("scatter-", method, ".pdf")),
+      plot = scatter,
+      height = 25,
+      width = 40,
+      units = "cm"
+    )
+
+    for (realOnly in c(TRUE, FALSE)) {
+      populationSuffix <- if (realOnly) "real-pops" else "all-pops"
+      for (metric in c("pcc", "ccc")) {
+        correlationPlot <- .acsCytofValidationPlotCorrelation(
+          correlationTbl = correlationTbl,
+          method = method,
+          metric = metric,
+          realPopulationsOnly = realOnly
+        )
+        ggplot2::ggsave(
+          file.path(
+            pathDirSave,
+            paste0("heatmap-", metric, "-", method, "-", populationSuffix, ".pdf")
+          ),
+          plot = correlationPlot,
+          height = 12.5,
+          width = 30,
+          units = "cm"
+        )
+      }
+    }
+  }
+
+  invisible(correlationTbl)
+}


### PR DESCRIPTION
Closes #349

## What this does

- adds a dedicated ACS validation stage that consumes the cached manual-comparison table from `analysis/9-real-compare-acs-cytof.qmd`
- recreates the ACS manuscript-style raw background-subtracted frequency plots separately for StimGate, F-beta and Tailgate
- computes PCC and CCC by method, population, cytokine and stimulus
- produces PCC/CCC heatmaps both for the original CD4/CD8/TCRgd comparison set and for all matched populations
- saves the correlation table alongside the existing ACS manual-comparison outputs
- adds analysis tests for CCC calculation, correlation summaries and plot construction

## Source alignment

The plotting layout and stimulus colours follow the existing ACS manuscript implementation in `SATVILab/ReportACSCyTOFTCells` (`R/plot_cyt.R` and its `fig-supp-cyt-auto_vs_manual` targets pipeline). The comparison table remains the one produced by the current StimGate ACS workflow, which already adapts the manual comparison machinery for the current cached outputs.

## Validation

Added focused analysis tests under `analysis/tests/testthat/test-acs-cytof-validation-plots.R`. Full figure generation still requires the ACS cached outputs and raw/reference data available in the project environment.